### PR TITLE
Support for nested list

### DIFF
--- a/src/main/scala/com/mdpeg/Block.scala
+++ b/src/main/scala/com/mdpeg/Block.scala
@@ -11,8 +11,8 @@ final case class BlockQuote(inline: String) extends Block
 final case class TableBlock(inline: String) extends Block
 
 // list cases
-final case class OrderedList(inline: Vector[Vector[Block]]) extends Block
-final case class UnorderedList(inline: Vector[Vector[Block]]) extends Block
+final case class OrderedList(inline: Vector[Block]) extends Block
+final case class UnorderedList(inline: Vector[Block]) extends Block
 
 /**
   * Raw markdown that is yet to be processed into blocks

--- a/src/main/scala/com/mdpeg/BlockParser.scala
+++ b/src/main/scala/com/mdpeg/BlockParser.scala
@@ -10,9 +10,7 @@ class BlockParser(val input: ParserInput) extends Parser with PrimitiveRules {
 
   //block definitions
   def verbatim : Rule1[Verbatim] = {
-    def math = rule { anyOf("=/\\*-+^%!<>[]{}") }
-    def other = rule {anyOf("@#$\"“")}
-    def inlineCodeChar = rule( inline | math | other ) // ToDo add blank line?
+    def inlineCodeChar = rule( inline | mathChar | specialChar ) // ToDo add blank line?
     def verbatimBlockBound = rule(3.times("`"))
     def verbatimBlockContents = rule((nl | inlineCodeChar.+ ~ nl).+)
     rule (verbatimBlockBound ~ capture(verbatimBlockContents) ~ verbatimBlockBound ~ blankLine.* ~> Verbatim)

--- a/src/main/scala/com/mdpeg/ListBlockParser.scala
+++ b/src/main/scala/com/mdpeg/ListBlockParser.scala
@@ -19,12 +19,16 @@ trait ListBlockParser extends PrimitiveRules {
   def bulletListSparse: Rule1[UnorderedList] = rule((bulletListItem ~ blankLine.*).+ ~> (toUnorderedList(_)))
   def bulletListItem: Rule1[Vector[String]] = {
     def listStart = rule(!horizontalRule ~ bullet)
-    def listRest  = rule(listContinuationBlock.* ~> ((x:Any)=> x.asInstanceOf[Vector[String]]))
-    def ff(x:String, y: Vector[String]): Vector[String] = {
-      println(s"Vector($x) ++ $y")
-      Vector(x) ++ y
+    def gg(x:Any) = {
+      println(s"listRest:{$x}")
+      x.asInstanceOf[String]
     }
-    rule(listStart ~ capture(listBlock) ~ listRest ~> ((x:String, y: Vector[String]) => ff(x,y)))
+    def listRest  = rule(listContinuationBlock ~> ((x:Any)=> gg(x)))
+    def ff(x:String, y: String): Vector[String] = {
+      println(s"Vector($x) ++ $y")
+      Vector(x) ++ Vector(y)
+    }
+    rule(listStart ~ capture(listBlock) ~ listRest ~> ((x:String, y: String) => ff(x,y)))
   }
 
   // ordered list
@@ -32,7 +36,12 @@ trait ListBlockParser extends PrimitiveRules {
   def orderedListSparse: Rule1[OrderedList] = rule((orderedListItem ~ blankLine.*).+ ~> (toOrderedList(_)))
   def orderedListItem: Rule1[Vector[String]] = {
     def listStart = rule(enumerator)
-    def listRest = rule(listContinuationBlock.* ~> ((x:Any)=> x.asInstanceOf[Vector[String]]))
+    def gg(x:Any) = {
+      println(s"listRest:{$x}")
+      x.asInstanceOf[Vector[String]]
+    }
+
+    def listRest = rule(listContinuationBlock.* ~> ((x:Any) => gg(x)))
     def ff(x:String, y: Vector[String]): Vector[String] = Vector(x) ++ y
     rule(listStart ~ capture(listBlock) ~ listRest ~> ((x:String, y: Vector[String]) => ff(x,y)))
   }
@@ -40,19 +49,12 @@ trait ListBlockParser extends PrimitiveRules {
   // aux list rules
   def listBlock: Rule0 = {
     def blockContents = rule(anyLine)
-    def notOptionallyIndentedAnyListItem = rule(!indent.? ~ (!bulletListItem | !orderedListItem))
+    def notOptionallyIndentedAnyListItem = rule(!(indent.? ~ (!bulletListItem | !orderedListItem)))
     def notPossibleStartOfAnyList        = rule(!indent ~ (!bullet | !enumerator))
     def blockRest = rule((notOptionallyIndentedAnyListItem ~ !blankLine ~ notPossibleStartOfAnyList ~ !indentedLine.?).*)
     rule(blockContents ~ blockRest)
   }
 
-//  def listBlock: Rule0 = {
-//    def blockContents = rule(anyLine.+) // ToDo this anyLine.+ handles some of the cases
-//    def notOptionallyIndentedAnyListItem = rule(!indent.? ~ (!bulletListItem | !orderedListItem))
-//    def notPossibleStartOfAnyList        = rule(!indent ~ (!bullet | !enumerator))
-//    def blockRest = rule((notOptionallyIndentedAnyListItem ~ !blankLine ~ notPossibleStartOfAnyList ~ !indentedLine.?).*)
-//    rule(blockContents ~ blockRest)
-//  }
   // ToDo improve continuation to handle inner lists
   def listContinuationBlock: Rule1[String] = {
     def blankLines: Rule1[String] = rule(capture(blankLine.+) ~> ((x: String) => identity(x)))
@@ -61,12 +63,14 @@ trait ListBlockParser extends PrimitiveRules {
       MATCH ~ push("{{md-break}}") ~> ((x: String) => identity(x))
     }
     def continuation: Rule0= rule((indent ~ listBlock).+)
+
     def ff(x: String, y:Any) ={
       println(s"y:${y}")
       x
     }
+
     rule {
-      (capture(blankLine.+) | MATCH ~ push("{{md-break}}")) ~ capture(continuation) ~> ((x: String, y:Any) => identity(x))
+      (capture(blankLine.+) | MATCH ~ push("{{md-break}}")) ~ capture(continuation) ~> ((x: String, y:Any) => ff(x,y))
     }
   }
 

--- a/src/main/scala/com/mdpeg/ListBlockParser.scala
+++ b/src/main/scala/com/mdpeg/ListBlockParser.scala
@@ -17,19 +17,21 @@ trait ListBlockParser extends PrimitiveRules {
   // unordered list
   def bulletListTight: Rule1[UnorderedList] = rule((bulletListItem.+ ~> (toUnorderedList(_))) ~ blankLine.* ~ !bulletListSparse)
   def bulletListSparse: Rule1[UnorderedList] = rule((bulletListItem ~ blankLine.*).+ ~> (toUnorderedList(_)))
-  def bulletListItem: Rule1[String] = {
+  def bulletListItem: Rule1[Vector[String]] = {
     def listStart = rule(!horizontalRule ~ bullet)
-    def listRest  = rule(listContinuationBlock.*)
-    rule(listStart ~ capture(listBlock) ~ listRest ~> (identity(_:String)))
+    def listRest  = rule(listContinuationBlock.* ~> ((x:Any)=> x.asInstanceOf[Vector[String]]))
+    def ff(x:String, y: Vector[String]): Vector[String] = Vector(x) ++ y
+    rule(listStart ~ capture(listBlock) ~ listRest ~> ((x:String, y: Vector[String]) => ff(x,y)))
   }
 
   // ordered list
   def orderedListTight: Rule1[OrderedList] = rule((orderedListItem.+ ~> (toOrderedList(_))) ~ blankLine.* ~ !orderedListSparse)
   def orderedListSparse: Rule1[OrderedList] = rule((orderedListItem ~ blankLine.*).+ ~> (toOrderedList(_)))
-  def orderedListItem: Rule1[String] = {
+  def orderedListItem: Rule1[Vector[String]] = {
     def listStart = rule(enumerator)
-    def listRest  = rule(listContinuationBlock.*)
-    rule(listStart ~ capture(listBlock) ~ listRest ~> (identity(_:String)))
+    def listRest = rule(listContinuationBlock.* ~> ((x:Any)=> x.asInstanceOf[Vector[String]]))
+    def ff(x:String, y: Vector[String]): Vector[String] = Vector(x) ++ y
+    rule(listStart ~ capture(listBlock) ~ listRest ~> ((x:String, y: Vector[String]) => ff(x,y)))
   }
 
   // aux list rules
@@ -41,8 +43,12 @@ trait ListBlockParser extends PrimitiveRules {
     rule(blockContents ~ blockRest)
   }
   // ToDo improve continuation to handle inner lists
-  def listContinuationBlock: Rule0 = rule(blankLine.+ ~ (indent ~ listBlock).+)
+  def listContinuationBlock:Rule1[String] = {
+    def blankLines:Rule1[String] = rule(capture(blankLine.+) ~> ((x:String) => identity(x)))
+    def markdownSeparator:Rule1[String] = rule{MATCH ~ push("{{md-break}}") ~> ((x:String) => identity(x))}
+    rule { (blankLines | markdownSeparator) ~ (indent ~ listBlock).+ }
+  }
 
-  private def toUnorderedList(x: Seq[String]) = UnorderedList(Vector(x.map(Markdown).toVector))
-  private def toOrderedList(x: Seq[String]) = OrderedList(Vector(x.map(Markdown).toVector))
+  private def toUnorderedList(x: Seq[Vector[String]]) = UnorderedList(x.map(_.map(Markdown)).toVector)
+  private def toOrderedList(x: Seq[Vector[String]]) = OrderedList(x.map(_.map(Markdown)).toVector)
 }

--- a/src/main/scala/com/mdpeg/ListBlockParser.scala
+++ b/src/main/scala/com/mdpeg/ListBlockParser.scala
@@ -21,7 +21,7 @@ trait ListBlockParser extends PrimitiveRules {
     def listStart = rule(!horizontalRule ~ bullet)
     def listRest  = rule(listContinuationBlock.*)
     def ff(x:String, y: String): Vector[String] = {
-      println(s"bulletListItem:Vector($x) ++ ($y)")
+      //println(s"bulletListItem:Vector($x) ++ ($y)")
       Vector(x+y)
     }
     rule(listStart ~ capture(listBlock) ~ capture(listRest) ~> ((x:String, y: String) => ff(x,y)))
@@ -34,7 +34,7 @@ trait ListBlockParser extends PrimitiveRules {
     def listStart = rule(enumerator)
     def listRest  = rule(listContinuationBlock.*)
     def ff(x:String, y: String): Vector[String] = {
-      println(s"bulletListItem:Vector($x) ++ ($y)")
+      //println(s"bulletListItem:Vector($x) ++ ($y)")
       Vector(x+y)
     }
     rule(listStart ~ capture(listBlock) ~ capture(listRest) ~> ((x:String, y: String) => ff(x,y)))

--- a/src/main/scala/com/mdpeg/PrimitiveRules.scala
+++ b/src/main/scala/com/mdpeg/PrimitiveRules.scala
@@ -14,7 +14,10 @@ trait PrimitiveRules {
   }
 
   def indentedLine    : Rule0 = rule(indent ~ anyLine)
-  def anyLine         : Rule0 = rule(!nl ~ !EOI ~ inline.+ ~ (nl | ""))
+  def anyLine         : Rule0 = rule(!nl ~ !EOI ~ anyChar.* ~ (nl | ""))
+  def anyChar         : Rule0 = rule(inline | mathChar | specialChar)
+  def mathChar        : Rule0 = rule { anyOf("=/\\*-+^%!<>[]{}") }
+  def specialChar     : Rule0 = rule {anyOf("@#$\"“")}
   def endLine         : Rule0 = rule(sp.? ~ nl ~ !blankLine ~ !EOI)
   def indent          : Rule0 = rule("\t" | "    ")
   def nonIndentSpace  : Rule0 = rule("   " | "  " | " " | "")

--- a/src/test/scala/BlockParserProps.scala
+++ b/src/test/scala/BlockParserProps.scala
@@ -3,11 +3,11 @@ import org.scalacheck.Prop.{BooleanOperators, forAll}
 import org.scalacheck.{Gen, Properties}
 
 object BlockParserProps extends Properties("BlockParser") {
-  val inline = Gen.alphaNumStr
+  val inline: Gen[String] = Gen.alphaNumStr
   property("Any alpha sequence followed by 'cr or crlf' is a paragraph of that sequence") = forAll(inline) { i =>
     (i != null && i != "") ==> {
     val term =
-      s"""${i}
+      s"""$i
         |
         |""".stripMargin
     val parsed = new BlockParser(term).paragraph.run().get

--- a/src/test/scala/ListParserSpec.scala
+++ b/src/test/scala/ListParserSpec.scala
@@ -1,3 +1,4 @@
+
 import com.mdpeg.{ListBlockParser, Markdown, OrderedList, UnorderedList}
 import org.parboiled2.{ErrorFormatter, ParseError, Parser, ParserInput}
 import org.scalatest.{FlatSpec, Matchers}
@@ -6,79 +7,97 @@ import scala.util.{Failure, Success, Try}
 
 class ListParserSpec extends FlatSpec with Matchers {
   class ListParserTestSpec(val input: ParserInput) extends Parser with ListBlockParser {}
-  object PrettyPrintListParser {
-    def apply(parser : ListParserTestSpec) : Unit= {
-      val result= parser.bulletListItem.run()
-      result match {
-        case Failure(error) =>
-          error match {
-            case e : ParseError => println(parser.formatError(e, new ErrorFormatter(showTraces = true)))
-            case _ => println(error)
-          }
-        case Success(value) => println(value)
-      }
-    }
-  }
-
-  def hasSucceededUnordered(parserResult: Try[UnorderedList]): Boolean = !hasFailedUnordered(parserResult)
-  def hasFailedUnordered(parserResult: Try[UnorderedList]): Boolean = parserResult match {
-    case Failure(_) => true
-    case Success(_) => false
-  }
-  def hasFailedOrdered(parsed: Try[OrderedList]) = parsed match {
-    case Failure(_) => true
-    case Success(_) => false
-  }
-
-  val expectedFirst =
-    s"""${TestData.firstItemInList}
-       |""".stripMargin
-  val expectedSecond =
-    s"""${TestData.secondItemInList}""".stripMargin
-
-  it should "parse unordered list's bullets '-*+'" in {
-    for (ch <- Vector("-","*","+")) {
-      val term = s"""$ch """.stripMargin
-      new ListParserTestSpec(term).bullet.run().get
-    }
-  }
-
-  it should "parse ordered list's enumerator 1..999" in {
-    for (d <- 1 to 999) {
-      val term = s"""$d. """.stripMargin
-      new ListParserTestSpec(term).enumerator.run().get
-    }
-  }
-
-  it should "parse tight bullet list" in {
-    val parsed = new ListParserTestSpec(TestData.tightUnorderedList).list.run()
-    parsed.get shouldEqual UnorderedList(Vector(Vector(Markdown(expectedFirst), Markdown(expectedSecond))))
-    println(parsed)
-  }
-
-  it should "fail on sparse bullet list while parsing it as tight" in {
-    val parsed: Try[UnorderedList] = new ListParserTestSpec(TestData.sparseUnorderedList).bulletListTight.run()
-    hasFailedUnordered(parsed) shouldEqual true
-  }
-
-  it should "parse sparse bullet list" in {
-    val parsed = new ListParserTestSpec(TestData.sparseUnorderedList).list.run()
-    parsed.get shouldEqual UnorderedList(Vector(Vector(Markdown(expectedFirst), Markdown(expectedSecond))))
-  }
-
-  it should "parse tight ordered list" in {
-    val parsed = new ListParserTestSpec(TestData.tightOrderedList).list.run()
-    parsed.get shouldEqual OrderedList(Vector(Vector(Markdown(expectedFirst), Markdown(expectedSecond))))
+//  object PrettyPrintListParser {
+//    def apply(parser : ListParserTestSpec) : Unit= {
+//      val result= parser.bulletListItem.run()
+//      result match {
+//        case Failure(error) =>
+//          error match {
+//            case e : ParseError => println(parser.formatError(e, new ErrorFormatter(showTraces = true)))
+//            case _ => println(error)
+//          }
+//        case Success(value) => println(value)
+//      }
+//    }
+//  }
+//
+//  def hasSucceededUnordered(parserResult: Try[UnorderedList]): Boolean = !hasFailedUnordered(parserResult)
+//  def hasFailedUnordered(parserResult: Try[UnorderedList]): Boolean = parserResult match {
+//    case Failure(_) => true
+//    case Success(_) => false
+//  }
+//  def hasFailedOrdered(parsed: Try[OrderedList]) = parsed match {
+//    case Failure(_) => true
+//    case Success(_) => false
+//  }
+//
+//  val expectedFirst =
+//    s"""${TestData.firstItemInList}
+//       |""".stripMargin
+//  val expectedSecond =
+//    s"""${TestData.secondItemInList}""".stripMargin
+//
+//  it should "parse unordered list's bullets '-*+'" in {
+//    for (ch <- Vector("-","*","+")) {
+//      val term = s"""$ch """.stripMargin
+//      new ListParserTestSpec(term).bullet.run().get
+//    }
+//  }
+//
+//  it should "parse ordered list's enumerator 1..999" in {
+//    for (d <- 1 to 999) {
+//      val term = s"""$d. """.stripMargin
+//      new ListParserTestSpec(term).enumerator.run().get
+//    }
+//  }
+//
+//  it should "parse tight bullet list" in {
+//    val parsed = new ListParserTestSpec(TestData.tightUnorderedList).list.run()
+//    parsed.get shouldEqual UnorderedList(Vector(Vector(Markdown(expectedFirst), Markdown(expectedSecond))))
+//  }
+//
+//  it should "fail on sparse bullet list while parsing it as tight" in {
+//    val parsed: Try[UnorderedList] = new ListParserTestSpec(TestData.sparseUnorderedList).bulletListTight.run()
+//    hasFailedUnordered(parsed) shouldEqual true
+//  }
+//
+//  it should "parse sparse bullet list" in {
+//    val parsed = new ListParserTestSpec(TestData.sparseUnorderedList).list.run()
+//    parsed.get shouldEqual UnorderedList(Vector(Vector(Markdown(expectedFirst), Markdown(expectedSecond))))
+//  }
+//
+//  it should "parse tight ordered list" in {
+//    val parsed = new ListParserTestSpec(TestData.tightOrderedList).list.run()
+//    parsed.get shouldEqual OrderedList(Vector(Vector(Markdown(expectedFirst), Markdown(expectedSecond))))
+//    println(parsed.get)
+//  }
+//
+//  it should "parse sparse ordered list" in {
+//    val parsed = new ListParserTestSpec(TestData.sparseOrderedList).list.run()
+//    parsed.get shouldEqual OrderedList(Vector(Vector(Markdown(expectedFirst), Markdown(expectedSecond))))
+//  }
+//
+//  it should "fail sparse ordered list while parsing it as list" in {
+//    val parsed = new ListParserTestSpec(TestData.sparseOrderedList).orderedListTight.run()
+//    hasFailedOrdered(parsed) shouldEqual true
+//  }
+  it should "123" in {
+    val term ="""* It is a long established fact that a reader will be distracted by the readable content of a
+                |  page when looking at its layout. The point of using Lorem Ipsum is that it has a more-or-less
+                |  normal distribution of letters, as opposed to using 'Content here, content here',
+                |  making it look like readable English. Many desktop publishing packages and web page
+                |* Second list block - editors now use Lorem Ipsum as their default model text, and a search for
+                |  'lorem ipsum' will uncover many web sites still in their infancy. Various versions
+                |  have evolved over the years, sometimes by accident, sometimes on purpose (.
+                |  injected humour and the like).
+                |  There are many variations of passages of Lorem Ipsum available, but the majority have
+                |  suffered alteration in some form, by injected humour, or randomised words
+                |  which don't look even slightly believable.
+                |* Third list block - If you are going to use a passage of Lorem Ipsum, you need to be
+                |* Fourth list block - sure there isn't anything embarrassing hidden in the middle
+                |  of text. All the Lorem Ipsum generators on the Internet tend to r""".stripMargin
+    val parsed = new ListParserTestSpec(term).unorderedList.run()
+    println("======================================")
     println(parsed.get)
-  }
-
-  it should "parse sparse ordered list" in {
-    val parsed = new ListParserTestSpec(TestData.sparseOrderedList).list.run()
-    parsed.get shouldEqual OrderedList(Vector(Vector(Markdown(expectedFirst), Markdown(expectedSecond))))
-  }
-
-  it should "fail sparse ordered list while parsing it as list" in {
-    val parsed = new ListParserTestSpec(TestData.sparseOrderedList).orderedListTight.run()
-    hasFailedOrdered(parsed) shouldEqual true
   }
 }

--- a/src/test/scala/ListParserSpec.scala
+++ b/src/test/scala/ListParserSpec.scala
@@ -8,80 +8,80 @@ import scala.util.{Failure, Success, Try}
 
 class ListParserSpec extends FlatSpec with Matchers {
   class ListParserTestSpec(val input: ParserInput) extends Parser with ListBlockParser {}
-//  object PrettyPrintListParser {
-//    def apply(parser : ListParserTestSpec) : Unit= {
-//      val result= parser.bulletListItem.run()
-//      result match {
-//        case Failure(error) =>
-//          error match {
-//            case e : ParseError => println(parser.formatError(e, new ErrorFormatter(showTraces = true)))
-//            case _ => println(error)
-//          }
-//        case Success(value) => println(value)
-//      }
-//    }
-//  }
-//
-//  def hasSucceededUnordered(parserResult: Try[UnorderedList]): Boolean = !hasFailedUnordered(parserResult)
-//  def hasFailedUnordered(parserResult: Try[UnorderedList]): Boolean = parserResult match {
-//    case Failure(_) => true
-//    case Success(_) => false
-//  }
-//  def hasFailedOrdered(parsed: Try[OrderedList]) = parsed match {
-//    case Failure(_) => true
-//    case Success(_) => false
-//  }
-//
-//  val expectedFirst =
-//    s"""${TestData.firstItemInList}
-//       |""".stripMargin
-//  val expectedSecond =
-//    s"""${TestData.secondItemInList}""".stripMargin
-//
-//  it should "parse unordered list's bullets '-*+'" in {
-//    for (ch <- Vector("-","*","+")) {
-//      val term = s"""$ch """.stripMargin
-//      new ListParserTestSpec(term).bullet.run().get
-//    }
-//  }
-//
-//  it should "parse ordered list's enumerator 1..999" in {
-//    for (d <- 1 to 999) {
-//      val term = s"""$d. """.stripMargin
-//      new ListParserTestSpec(term).enumerator.run().get
-//    }
-//  }
-//
-//  it should "parse tight bullet list" in {
-//    val parsed = new ListParserTestSpec(TestData.tightUnorderedList).list.run()
-//    parsed.get shouldEqual UnorderedList(Vector(Vector(Markdown(expectedFirst), Markdown(expectedSecond))))
-//  }
-//
-//  it should "fail on sparse bullet list while parsing it as tight" in {
-//    val parsed: Try[UnorderedList] = new ListParserTestSpec(TestData.sparseUnorderedList).bulletListTight.run()
-//    hasFailedUnordered(parsed) shouldEqual true
-//  }
-//
-//  it should "parse sparse bullet list" in {
-//    val parsed = new ListParserTestSpec(TestData.sparseUnorderedList).list.run()
-//    parsed.get shouldEqual UnorderedList(Vector(Vector(Markdown(expectedFirst), Markdown(expectedSecond))))
-//  }
-//
-//  it should "parse tight ordered list" in {
-//    val parsed = new ListParserTestSpec(TestData.tightOrderedList).list.run()
-//    parsed.get shouldEqual OrderedList(Vector(Vector(Markdown(expectedFirst), Markdown(expectedSecond))))
-//    println(parsed.get)
-//  }
-//
-//  it should "parse sparse ordered list" in {
-//    val parsed = new ListParserTestSpec(TestData.sparseOrderedList).list.run()
-//    parsed.get shouldEqual OrderedList(Vector(Vector(Markdown(expectedFirst), Markdown(expectedSecond))))
-//  }
-//
-//  it should "fail sparse ordered list while parsing it as list" in {
-//    val parsed = new ListParserTestSpec(TestData.sparseOrderedList).orderedListTight.run()
-//    hasFailedOrdered(parsed) shouldEqual true
-//  }
+  object PrettyPrintListParser {
+    def apply(parser : ListParserTestSpec) : Unit= {
+      val result= parser.bulletListItem.run()
+      result match {
+        case Failure(error) =>
+          error match {
+            case e : ParseError => println(parser.formatError(e, new ErrorFormatter(showTraces = true)))
+            case _ => println(error)
+          }
+        case Success(value) => println(value)
+      }
+    }
+  }
+
+  def hasSucceededUnordered(parserResult: Try[UnorderedList]): Boolean = !hasFailedUnordered(parserResult)
+  def hasFailedUnordered(parserResult: Try[UnorderedList]): Boolean = parserResult match {
+    case Failure(_) => true
+    case Success(_) => false
+  }
+  def hasFailedOrdered(parsed: Try[OrderedList]) = parsed match {
+    case Failure(_) => true
+    case Success(_) => false
+  }
+
+  val expectedFirst =
+    s"""${TestData.firstItemInList}
+       |""".stripMargin
+  val expectedSecond =
+    s"""${TestData.secondItemInList}""".stripMargin
+
+  it should "parse unordered list's bullets '-*+'" in {
+    for (ch <- Vector("-","*","+")) {
+      val term = s"""$ch """.stripMargin
+      new ListParserTestSpec(term).bullet.run().get
+    }
+  }
+
+  it should "parse ordered list's enumerator 1..999" in {
+    for (d <- 1 to 999) {
+      val term = s"""$d. """.stripMargin
+      new ListParserTestSpec(term).enumerator.run().get
+    }
+  }
+
+  it should "parse tight bullet list" in {
+    val parsed = new ListParserTestSpec(TestData.tightUnorderedList).list.run()
+    parsed.get shouldEqual UnorderedList(Vector(Markdown(expectedFirst), Markdown(expectedSecond)))
+  }
+
+  it should "fail on sparse bullet list while parsing it as tight" in {
+    val parsed: Try[UnorderedList] = new ListParserTestSpec(TestData.sparseUnorderedList).bulletListTight.run()
+    hasFailedUnordered(parsed) shouldEqual true
+  }
+
+  it should "parse sparse bullet list" in {
+    val parsed = new ListParserTestSpec(TestData.sparseUnorderedList).list.run()
+    parsed.get shouldEqual UnorderedList(Vector(Markdown(expectedFirst), Markdown(expectedSecond)))
+  }
+
+  it should "parse tight ordered list" in {
+    val parsed = new ListParserTestSpec(TestData.tightOrderedList).list.run()
+    parsed.get shouldEqual OrderedList(Vector(Markdown(expectedFirst), Markdown(expectedSecond)))
+    println(parsed.get)
+  }
+
+  it should "parse sparse ordered list" in {
+    val parsed = new ListParserTestSpec(TestData.sparseOrderedList).list.run()
+    parsed.get shouldEqual OrderedList(Vector(Markdown(expectedFirst), Markdown(expectedSecond)))
+  }
+
+  it should "fail sparse ordered list while parsing it as list" in {
+    val parsed = new ListParserTestSpec(TestData.sparseOrderedList).orderedListTight.run()
+    hasFailedOrdered(parsed) shouldEqual true
+  }
 
   /* ToDo:
   * 1. indent is set to 4 spaces - should it be fixed or allow 2/4 spaces for case when we are inside of list item already
@@ -95,17 +95,17 @@ class ListParserSpec extends FlatSpec with Matchers {
                 |    normal distribution of letters, as opposed to using 'Content here, content here',
                 |    making it look like readable English. Many desktop publishing packages and web page
                 |* 2nd list block - editors now use Lorem Ipsum as their default model text, and a search for
-                |  'lorem ipsum' will uncover many web sites still in their infancy. Various versions
-                |  have evolved over the years, sometimes by accident, sometimes on purpose (.
-                |  injected humour and the like).
-                |  There are many variations of passages of Lorem Ipsum available, but the majority have
-                |  suffered alteration in some form, by injected humour, or randomised words
-                |  which don't look even slightly believable.
+                |     'lorem ipsum' will uncover many web sites still in their infancy. Various versions
+                |     have evolved over the years, sometimes by accident, sometimes on purpose (.
+                |     injected humour and the like).
+                |     There are many variations of passages of Lorem Ipsum available, but the majority have
+                |     suffered alteration in some form, by injected humour, or randomised words
+                |     which don't look even slightly believable.
                 |* 3rd list block - If you are going to use a passage of Lorem Ipsum, you need to be
                 |* 4th list block - sure there isn't anything embarrassing hidden in the middle
-                |  of text. All the Lorem Ipsum generators on the Internet tend to r""".stripMargin
+                |    of text. All the Lorem Ipsum generators on the Internet tend to r""".stripMargin
     val parser = new ListParserTestSpec(term)
-    parser.unorderedList.run() match {
+    parser.list.run() match {
       case Success(node) => println(node)
       case Failure(e: ParseError) =>
         println(parser.formatError(e, new ErrorFormatter(showTraces = true)))
@@ -113,4 +113,17 @@ class ListParserSpec extends FlatSpec with Matchers {
         throw e
     println("======================================")
   }}
+  it should "456" in {
+    val term =""" - item
+                |     - sub
+                |     - sub""".stripMargin
+    val parser = new ListParserTestSpec(term)
+    parser.list.run() match {
+      case Success(node) => println(node)
+      case Failure(e: ParseError) =>
+        println(parser.formatError(e, new ErrorFormatter(showTraces = true)))
+      case Failure(e) =>
+        throw e
+        println("======================================")
+    }}
 }

--- a/src/test/scala/ListParserSpec.scala
+++ b/src/test/scala/ListParserSpec.scala
@@ -1,4 +1,5 @@
 
+import com.mdpeg.Parser.parser
 import com.mdpeg.{ListBlockParser, Markdown, OrderedList, UnorderedList}
 import org.parboiled2.{ErrorFormatter, ParseError, Parser, ParserInput}
 import org.scalatest.{FlatSpec, Matchers}
@@ -81,23 +82,35 @@ class ListParserSpec extends FlatSpec with Matchers {
 //    val parsed = new ListParserTestSpec(TestData.sparseOrderedList).orderedListTight.run()
 //    hasFailedOrdered(parsed) shouldEqual true
 //  }
+
+  /* ToDo:
+  * 1. indent is set to 4 spaces - should it be fixed or allow 2/4 spaces for case when we are inside of list item already
+  * 2. a list item should include block of raw markdown
+  * 3. an list should contain items that contains raw markdown.
+  * 4. should start parser recursively for a markdown - at which point?
+  */
   it should "123" in {
-    val term ="""* It is a long established fact that a reader will be distracted by the readable content of a
-                |  page when looking at its layout. The point of using Lorem Ipsum is that it has a more-or-less
-                |  normal distribution of letters, as opposed to using 'Content here, content here',
-                |  making it look like readable English. Many desktop publishing packages and web page
-                |* Second list block - editors now use Lorem Ipsum as their default model text, and a search for
+    val term ="""* 1st block - It is a long established fact that a reader will be distracted by the readable content of a
+                |    page when looking at its layout. The point of using Lorem Ipsum is that it has a more-or-less
+                |    normal distribution of letters, as opposed to using 'Content here, content here',
+                |    making it look like readable English. Many desktop publishing packages and web page
+                |* 2nd list block - editors now use Lorem Ipsum as their default model text, and a search for
                 |  'lorem ipsum' will uncover many web sites still in their infancy. Various versions
                 |  have evolved over the years, sometimes by accident, sometimes on purpose (.
                 |  injected humour and the like).
                 |  There are many variations of passages of Lorem Ipsum available, but the majority have
                 |  suffered alteration in some form, by injected humour, or randomised words
                 |  which don't look even slightly believable.
-                |* Third list block - If you are going to use a passage of Lorem Ipsum, you need to be
-                |* Fourth list block - sure there isn't anything embarrassing hidden in the middle
+                |* 3rd list block - If you are going to use a passage of Lorem Ipsum, you need to be
+                |* 4th list block - sure there isn't anything embarrassing hidden in the middle
                 |  of text. All the Lorem Ipsum generators on the Internet tend to r""".stripMargin
-    val parsed = new ListParserTestSpec(term).unorderedList.run()
+    val parser = new ListParserTestSpec(term)
+    parser.unorderedList.run() match {
+      case Success(node) => println(node)
+      case Failure(e: ParseError) =>
+        println(parser.formatError(e, new ErrorFormatter(showTraces = true)))
+      case Failure(e) =>
+        throw e
     println("======================================")
-    println(parsed.get)
-  }
+  }}
 }

--- a/src/test/scala/ListParserSpec.scala
+++ b/src/test/scala/ListParserSpec.scala
@@ -34,8 +34,7 @@ class ListParserSpec extends FlatSpec with Matchers {
     s"""${TestData.firstItemInList}
        |""".stripMargin
   val expectedSecond =
-    s"""${TestData.secondItemInList}
-       |""".stripMargin
+    s"""${TestData.secondItemInList}""".stripMargin
 
   it should "parse unordered list's bullets '-*+'" in {
     for (ch <- Vector("-","*","+")) {
@@ -54,6 +53,7 @@ class ListParserSpec extends FlatSpec with Matchers {
   it should "parse tight bullet list" in {
     val parsed = new ListParserTestSpec(TestData.tightUnorderedList).list.run()
     parsed.get shouldEqual UnorderedList(Vector(Vector(Markdown(expectedFirst), Markdown(expectedSecond))))
+    println(parsed)
   }
 
   it should "fail on sparse bullet list while parsing it as tight" in {
@@ -69,6 +69,7 @@ class ListParserSpec extends FlatSpec with Matchers {
   it should "parse tight ordered list" in {
     val parsed = new ListParserTestSpec(TestData.tightOrderedList).list.run()
     parsed.get shouldEqual OrderedList(Vector(Vector(Markdown(expectedFirst), Markdown(expectedSecond))))
+    println(parsed.get)
   }
 
   it should "parse sparse ordered list" in {

--- a/src/test/scala/ListParserSpec.scala
+++ b/src/test/scala/ListParserSpec.scala
@@ -72,7 +72,6 @@ class ListParserSpec extends FlatSpec with Matchers {
   it should "parse tight ordered list" in {
     val parsed = new ListParserTestSpec(TestData.tightOrderedList).list.run()
     parsed.get shouldEqual OrderedList(Vector(Markdown(expectedFirst), Markdown(expectedSecond)))
-    println(parsed.get)
   }
 
   it should "parse sparse ordered list" in { // ToDo fix rules to get rid of these trailing blank lines
@@ -87,7 +86,7 @@ class ListParserSpec extends FlatSpec with Matchers {
     hasFailedOrdered(parsed) shouldEqual true
   }
 
-  it should "create markdown for every list item" in {
+  it should "create markdown for every list item in unordered list" in {
     val term ="""* 1st block - It is a long established fact that a reader will be distracted by the readable content of a
                 |  page when looking at its layout. The point of using Lorem Ipsum is that it has a more-or-less
                 |    normal distribution of letters, as opposed to using 'Content here, content here',
@@ -117,7 +116,7 @@ class ListParserSpec extends FlatSpec with Matchers {
                    |    of text. All the Lorem Ipsum generators on the Internet tend to r""".stripMargin)))
   }
 
-  it should "create markdown for each full/half indented chunk" in {
+  it should "create markdown for each full/half indented chunk in unordered list" in {
     val term =
       """- item 1
         |     - sub 1
@@ -135,5 +134,25 @@ class ListParserSpec extends FlatSpec with Matchers {
         Markdown("""item 2
                    |  - sub 3
                    |  - sub 4""".stripMargin)))
+  }
+
+    it should "create markdown for each full/half indented chunk in ordered list" in {
+      val term =
+        """1. item 1
+          |     1. sub 1
+          |     2. sub 2
+          |2. item 2
+          |  1. sub 3
+          |  2. sub 4""".stripMargin
+      val parser = new ListParserTestSpec(term)
+      parser.list.run().get shouldEqual OrderedList(
+        Vector(
+          Markdown("""item 1
+                     |     1. sub 1
+                     |     2. sub 2
+                     |""".stripMargin),
+          Markdown("""item 2
+                     |  1. sub 3
+                     |  2. sub 4""".stripMargin)))
   }
 }

--- a/src/test/scala/TestData.scala
+++ b/src/test/scala/TestData.scala
@@ -124,8 +124,7 @@ object TestData {
        """.stripMargin
   val tightOrderedList: String =
     s"""1. $firstItemInList
-       |2. $secondItemInList
-       """.stripMargin
+       |2. $secondItemInList""".stripMargin
   val sparseUnorderedList: String =
     s"""- $firstItemInList
        |
@@ -134,8 +133,7 @@ object TestData {
        """.stripMargin
   val tightUnorderedList: String =
     s"""- $firstItemInList
-       |- $secondItemInList
-       """.stripMargin
+       |- $secondItemInList""".stripMargin
   val compoundMD: String =
     s"""# $headingOne
        |


### PR DESCRIPTION
Modified list rules to support full/half indent, that is now you can write
```
- list item
  -  first sublist item
  -  second sublist item
```
and it will be translated into the following AST node
```
Markdown(list item
<...>
)
```
where the rest of the text, that is`<...>`, is untouched. This is required to further process list items, as it may contain a various number of different blocks.
