### PR TITLE
Multiline tables support

### DIFF
--- a/src/main/resources/com/mdpeg/multiline table_complex.md
+++ b/src/main/resources/com/mdpeg/multiline table_complex.md
@@ -1,0 +1,35 @@
+--------------------------------------------------------------------------------
+LorimIpsum                        Where can I get some?
+-----------                       ---------------------------------
+**Why do we use it?**                 
+
+There-are                         It is a long established fact that a reader will be
+                                  distracted by the readable content of a page when looking at
+
+**Where can I get some?**                  
+
+dummy                             It uses a dictionary of over 
+                                  Lorem Ipsum which looks reasonable
+
+text                              The generated Lorem Ipsum is
+
+printing                          or non-characteristic words etc
+
+**Where does it come from?**                       
+
+leap-into                         It uses a dictionary of over 200
+                                  you need to be sure there
+
+variations-join                   anything embarrassing hidden 
+                                  you need to be sure there isn't
+                                  within this period
+
+**What is Lorem Ipsum?**                 
+ 
+Lorem                             "There are many variations of passages.
+                                  *randomised words which : 1597 z*
+
+anything                          but the majority have suffered alteration.
+                                  *to use a passage: "" (empty string)*
+--------------------------------------------------------------------------------
+Table: This is a table caption\label{table:table_lable_name}

--- a/src/main/resources/com/mdpeg/multiline table_one-liners.md
+++ b/src/main/resources/com/mdpeg/multiline table_one-liners.md
@@ -1,0 +1,9 @@
+--------------------------------------------------------------------------------
+Term                  Description
+----------------      ------------------------------------------------
+.It                   is a long established fact that
+
+CAPSED WORD           The point of using Lorem Ipsum is
+
+Many                   desktop publishing packages and
+--------------------------------------------------------------------------------

--- a/src/main/scala/com/mdpeg/Block.scala
+++ b/src/main/scala/com/mdpeg/Block.scala
@@ -21,6 +21,10 @@ sealed trait MultilineTableElement
 final case class MultilineTableTitle(inline: Markdown) extends MultilineTableElement
 final case class MultilineTableColumnHeader(inline: Markdown) extends MultilineTableElement
 final case class MultilineTableCell(inline: Markdown) extends MultilineTableElement
+// ToDo may header not present?
+// ToDo case class for row?
+// ToDo capture alignment
+// ToDo capture relative width of a column
 
 /**
   * Raw markdown that is yet to be processed into blocks

--- a/src/main/scala/com/mdpeg/Block.scala
+++ b/src/main/scala/com/mdpeg/Block.scala
@@ -8,11 +8,19 @@ case object HorizontalRuleBlock extends Block
 final case class HeadingBlock(level: Int, inline: String) extends Block
 final case class Verbatim(inline: String) extends Block
 final case class BlockQuote(inline: String) extends Block
-final case class TableBlock(inline: String) extends Block
+
 
 // list cases
 final case class OrderedList(inline: Vector[Block]) extends Block
 final case class UnorderedList(inline: Vector[Block]) extends Block
+
+//
+final case class MultilineTableBlock(inline: String) extends Block
+
+sealed trait MultilineTableElement
+final case class MultilineTableTitle(inline: Markdown) extends MultilineTableElement
+final case class MultilineTableColumnHeader(inline: Markdown) extends MultilineTableElement
+final case class MultilineTableCell(inline: Markdown) extends MultilineTableElement
 
 /**
   * Raw markdown that is yet to be processed into blocks

--- a/src/main/scala/com/mdpeg/Block.scala
+++ b/src/main/scala/com/mdpeg/Block.scala
@@ -14,20 +14,19 @@ final case class BlockQuote(inline: String) extends Block
 final case class OrderedList(inline: Vector[Block]) extends Block
 final case class UnorderedList(inline: Vector[Block]) extends Block
 
-//
-final case class MultilineTableBlock(inline: String) extends Block
-
+// multiline table
+final case class MultilineTableBlock(relativeWidth: Vector[Float],
+                                     caption: Option[MultilineTableCaption],
+                                     head: Option[MultilineTableRow],
+                                     body: Vector[MultilineTableColumn]) extends Block
 sealed trait MultilineTableElement
-final case class MultilineTableTitle(inline: Markdown) extends MultilineTableElement
-final case class MultilineTableColumnHeader(inline: Markdown) extends MultilineTableElement
-final case class MultilineTableCell(inline: Markdown) extends MultilineTableElement
-// ToDo may header not present?
-// ToDo case class for row?
+case class MultilineTableCaption(inline: Markdown) extends MultilineTableElement
+case class MultilineTableCell(inline: Markdown) extends MultilineTableElement
 // ToDo capture alignment
-// ToDo capture relative width of a column
 
 /**
   * Raw markdown that is yet to be processed into blocks
+  *
   * @param inline - raw string
   */
 final case class Markdown(inline: String) extends Block

--- a/src/main/scala/com/mdpeg/MultilineTablesParser.scala
+++ b/src/main/scala/com/mdpeg/MultilineTablesParser.scala
@@ -1,6 +1,8 @@
 package com.mdpeg
 
 import org.parboiled2._
+
+import scala.util.Success
 trait MultilineTablesParser extends PrimitiveRules {
   this: Parser =>
 
@@ -15,13 +17,32 @@ trait MultilineTablesParser extends PrimitiveRules {
   def tableBodyRaw: Rule1[Vector[String]] = {
     def bodyContentLine = rule(capture(atomic(!tableBorder ~ anyLine | blankLine)))
     def contents = rule(bodyContentLine.+)
-    def parseBodyContent(x: Vector[String]) = {
-      println("parseBodyContent-------")
-      println(s"x:${x}")
-      x
+    def parseBodyContent(sep:String, contents: Seq[String]) = {
+      def isEmptyString(input:String) = {
+        new PrimitvePaserHelper(input).blankLine.run() match {
+          case Success(node) => true
+          case _ => false
+        }
+      }
+
+      // ToDo scan through to determine positions of every width separator
+      val widths = sep.split(' ').filter(_ != "").map(_.replaceAll("\r","").replace("\n","")).toVector
+
+      //ToDo filter out empty entries that might occur in case there're more than 2 empty lines in a row
+      val rows = contents.foldLeft(List.empty[List[String]]) {
+        case (acc, currentLine) =>
+          if(isEmptyString(currentLine))
+            List.empty[String] :: acc
+          else
+            acc match {
+              case x::xs => (x :+ currentLine) :: xs
+              case Nil => List(currentLine) :: Nil
+            }
+      }
+      contents.toVector
     }
 
-    rule(capture(tableHeadWidthSeparator) ~ capture(contents) ~> ((sep:String, contents: Seq[String], _: Any) => parseBodyContent(contents.toVector)))
+    rule(capture(tableHeadWidthSeparator) ~ capture(contents) ~> ((sep:String, contents: Seq[String], _: Any) => parseBodyContent(sep, contents)))
   }
 
   // ToDO in case of 1 column it can't be distinguished from tableBorder rule, so no !tableBorder applied here yet
@@ -31,6 +52,12 @@ trait MultilineTablesParser extends PrimitiveRules {
 
   //aux rules
   private def dashes: Rule0 = rule((3 to 150).times("-"))
+
+
+
+  // ToDo investigate hot to re-use parser on differen inputs in order to avoid creation of a new parser on every line
+  // needed to facilitate some internal processing
+  private class PrimitvePaserHelper(val input:ParserInput) extends Parser with PrimitiveRules
 
   /* ToDo think about
 * 1. capturing relative width of columns

--- a/src/main/scala/com/mdpeg/MultilineTablesParser.scala
+++ b/src/main/scala/com/mdpeg/MultilineTablesParser.scala
@@ -5,4 +5,10 @@ trait MultilineTablesParser extends PrimitiveRules {
   this: Parser =>
   import CharPredicate._
 
+/* ToDo think about
+* 1. capturing relative width of columns
+* 2. capturing table caption
+* 3. would it be easier to process row by row instead of immediately trying to split everything into cells?
+* 4. rows are separated by blank lines
+*/
 }

--- a/src/main/scala/com/mdpeg/MultilineTablesParser.scala
+++ b/src/main/scala/com/mdpeg/MultilineTablesParser.scala
@@ -6,6 +6,10 @@ trait MultilineTablesParser extends PrimitiveRules {
   import CharPredicate._
 
   def multiTable = ???
+
+  def tableHead: Rule1[String] = rule(tableBorder ~ capture(anyChar.+) ~ nl ~ tableHeadWidthSeparator)
+  // ToDO in case of 1 column it can't be distinguished from tableBorder rule, so no !tableBorder applied here yet
+  def tableHeadWidthSeparator:Rule0 = rule(!horizontalRule ~ ((3 to 150).times("-") ~ sp.*).+ ~ nl.?)
   def tableBorder: Rule0 = rule(!horizontalRule ~ (3 to 150).times("-") ~ nl)
   def tableCaption: Rule0 = rule("Table: " ~ anyChar.+ ~ nl.?)
   //ToDo def heading content?

--- a/src/main/scala/com/mdpeg/MultilineTablesParser.scala
+++ b/src/main/scala/com/mdpeg/MultilineTablesParser.scala
@@ -6,16 +6,23 @@ trait MultilineTablesParser extends PrimitiveRules {
 
   def multiTable = ???
 
-  def tableHead: Rule1[String] = {
-    def headContentLine = rule(!tableHeadWidthSeparator ~ anyLine | blankLine)
-    rule(tableBorder ~ capture(headContentLine.+) ~ tableHeadWidthSeparator)
+  def tableHeadRaw: Rule0 = {
+    def headContentLine = rule(atomic(!tableHeadWidthSeparator ~ anyLine | blankLine))
+    rule(tableBorder ~ headContentLine.+ ~ tableHeadWidthSeparator)
+  }
+
+  def tableBodyRaw: Rule0 = {
+    def bodyContentLine = rule(atomic(!tableBorder ~ anyLine | blankLine))
+    rule(tableHeadWidthSeparator ~ bodyContentLine.+ ~ tableBorder)
   }
 
   // ToDO in case of 1 column it can't be distinguished from tableBorder rule, so no !tableBorder applied here yet
-  def tableHeadWidthSeparator:Rule0 = rule(!horizontalRule ~ ((3 to 150).times("-") ~ sp.*).+ ~ nl.?)
-  def tableBorder: Rule0 = rule(!horizontalRule ~ (3 to 150).times("-") ~ nl)
-  def tableCaption: Rule0 = rule("Table: " ~ anyChar.+ ~ nl.?)
-  //ToDo def heading content?
+  def tableHeadWidthSeparator: Rule0 = rule(atomic(!horizontalRule ~ (dashes ~ sp.*).+ ~ nl.?))
+  def tableBorder: Rule0 = rule(atomic(!horizontalRule ~ dashes ~ nl))
+  def tableCaption: Rule0 = rule(atomic("Table: " ~ anyChar.+ ~ nl.?))
+
+  //aux rules
+  private def dashes: Rule0 = rule((3 to 150).times("-"))
 /* ToDo think about
 * 1. capturing relative width of columns
 * 2. capturing table caption

--- a/src/main/scala/com/mdpeg/MultilineTablesParser.scala
+++ b/src/main/scala/com/mdpeg/MultilineTablesParser.scala
@@ -4,18 +4,24 @@ import org.parboiled2._
 trait MultilineTablesParser extends PrimitiveRules {
   this: Parser =>
 
-  def multiTable = rule {  tableHeadRaw.? ~ tableBodyRaw ~ tableCaption.? }
+  def multiTable = rule { tableHeadRaw ~ tableBodyRaw ~ tableBorder ~ tableCaption.? }
 
   def tableHeadRaw: Rule1[Vector[String]] = {
     def headContentLine = rule(capture(atomic(!tableHeadWidthSeparator ~ anyLine | blankLine)))
     def contents :Rule1[Seq[String]] = rule(headContentLine.+)
-    rule(tableBorder ~ capture(contents) ~ tableHeadWidthSeparator ~> ((y:Seq[String],_:Any) => y.toVector))
+    rule(tableBorder ~ capture(contents) ~ &(tableHeadWidthSeparator) ~> ((y:Seq[String],_:Any) => y.toVector))
   }
 
   def tableBodyRaw: Rule1[Vector[String]] = {
     def bodyContentLine = rule(capture(atomic(!tableBorder ~ anyLine | blankLine)))
     def contents = rule(bodyContentLine.+)
-    rule(capture(contents) ~ tableBorder ~> ((contents: Seq[String], _: Any) => contents.toVector))
+    def parseBodyContent(x: Vector[String]) = {
+      println("parseBodyContent-------")
+      println(s"x:${x}")
+      x
+    }
+
+    rule(capture(tableHeadWidthSeparator) ~ capture(contents) ~> ((sep:String, contents: Seq[String], _: Any) => parseBodyContent(contents.toVector)))
   }
 
   // ToDO in case of 1 column it can't be distinguished from tableBorder rule, so no !tableBorder applied here yet

--- a/src/main/scala/com/mdpeg/MultilineTablesParser.scala
+++ b/src/main/scala/com/mdpeg/MultilineTablesParser.scala
@@ -39,20 +39,24 @@ trait MultilineTablesParser extends PrimitiveRules {
             case Nil => List(currentLine) :: Nil
           }
       }.reverse
-      val cols = rows
+
+      val cells = rows
         .map(_.map(_.zip(widths).toList))
         .map(_.foldLeft(List.empty[List[String]]) {
           case (acc, currentLine) =>
             currentLine.foldLeft(List.empty[String]) {
-              case (acc1: List[String], cl: (Char, Char)) =>
+              case (acc1, cl) =>
                 (acc1,cl) match {
                 case (x::xs, (c, '-')) => (x + c.toString) :: xs
                 case (xs, (_, ' ')) => "" :: xs
                 case (Nil, (c, '-')) => c.toString :: Nil
-                case (Nil, (_, ' ')) => Nil
+                case _ => Nil
             }
           }.filter(_!="").reverse :: acc
         })
+        .transpose(_.transpose.map(_.reverse.reduce(_.trim+"\r\n"+_.trim)))
+      //todo use smtng else instead of \r\n?
+
       contents.toVector
     }
 

--- a/src/main/scala/com/mdpeg/MultilineTablesParser.scala
+++ b/src/main/scala/com/mdpeg/MultilineTablesParser.scala
@@ -7,7 +7,8 @@ trait MultilineTablesParser extends PrimitiveRules {
 
   def multiTable = ???
   def tableBorder: Rule0 = rule(!horizontalRule ~ (3 to 150).times("-") ~ nl)
-
+  def tableCaption: Rule0 = rule("Table: " ~ anyChar.+ ~ nl.?)
+  //ToDo def heading content?
 /* ToDo think about
 * 1. capturing relative width of columns
 * 2. capturing table caption

--- a/src/main/scala/com/mdpeg/MultilineTablesParser.scala
+++ b/src/main/scala/com/mdpeg/MultilineTablesParser.scala
@@ -1,29 +1,29 @@
 package com.mdpeg
-
 import org.parboiled2._
 
-import scala.collection.immutable
 import scala.collection.immutable.::
+import scala.compat.Platform.EOL
 import scala.util.Success
 trait MultilineTablesParser extends PrimitiveRules {
   this: Parser =>
   /*_*/
-  def multiTable = rule(
-    tableHeadRaw.? ~ tableBodyRaw ~ tableBorder ~ tableCaption.? ~>
-      ((head: Option[Vector[String]], body:(Vector[List[String]], String), caption:Option[String]) => constructTable(head, body, caption))
+  def multiTable: Rule1[MultilineTableBlock] = rule(
+    tableHeadRaw.? ~ tableBody ~ tableBorder ~ tableCaption.? ~>
+      ((head: Option[Vector[String]], body: (Vector[List[String]], String), caption: Option[String]) => constructTable(head, body, caption))
   )
   /*_*/
 
-  def constructTable(head: Option[Vector[String]], bodyWithWidth:(Vector[List[String]], String), caption:Option[String]) = {
-    def calculateRelativeWidths(width: String) : Vector[Float] = {
+  def constructTable(head: Option[Vector[String]], bodyWithWidth: (Vector[List[String]], String), caption: Option[String]): MultilineTableBlock = {
+    def calculateRelativeWidths(width: String): Vector[Float] = {
       // todo improve calculation precision, use Largest Remainder Method and imrove upon relative error
-      val columnWidths = width.split(' ').filter(_!="").map(_.length)
+      val columnWidths = width.split(' ').filter(_ != "").map(_.length)
       val sum = columnWidths.sum.toFloat
-      columnWidths.map(100*_.toFloat/sum).toVector
+      columnWidths.map(100 * _.toFloat / sum).toVector
     }
+
     val (body, width: String) = bodyWithWidth
     val parsedHead = head.map(parseHeadContent(width, _))
-    
+
     val relativeWidths = calculateRelativeWidths(width)
     val tableCaption = caption.map(y => MultilineTableCaption(Markdown(y)))
     val headRow: Option[MultilineTableRow] = parsedHead.map(_.map(inline => MultilineTableCell(Markdown(inline))).toVector)
@@ -37,7 +37,7 @@ trait MultilineTablesParser extends PrimitiveRules {
     rule(tableBorder ~ capture(contents) ~ &(tableHeadWidthSeparator) ~> ((headContent:Seq[String],_:Any) => headContent.toVector))
   }
 
-  def tableBodyRaw: Rule1[(Vector[List[String]], String)] = {
+  def tableBody: Rule1[(Vector[List[String]], String)] = {
     def bodyContentLine = rule(capture(atomic(!tableBorder ~ anyLine | blankLine)))
     def contents = rule(bodyContentLine.+)
     rule(capture(tableHeadWidthSeparator) ~ capture(contents) ~>
@@ -48,11 +48,15 @@ trait MultilineTablesParser extends PrimitiveRules {
   def tableHeadWidthSeparator: Rule0 = rule(atomic(!horizontalRule ~ (dashes ~ sp.*).+ ~ nl.?))
   def tableBorder: Rule0 = rule(atomic(!horizontalRule ~ dashes ~ nl))
   def tableCaption: Rule1[String] = rule(atomic("Table: " ~ capture(anyChar.+ ~ nl.?)))
+  def dashes: Rule0 = rule((3 to 150).times("-"))
 
-  //aux rules
-  private def dashes: Rule0 = rule((3 to 150).times("-"))
-
-  //aux functions
+  /**
+    * Splits header content into cells using 'width separator'
+    * @param sep width separator string, '-- --- --'
+    * @param contents raw contents of the table head to be split into cells; blank lines removed, that is,
+    *                 there's no support for multi-row headers
+    * @return vector of cells in a header row
+    */
   private def parseHeadContent(sep: String, contents: Seq[String]) = {
     def isEmptyString(input: String) = {
       new PrimitvePaserHelper(input).blankLine.run() match {
@@ -77,9 +81,9 @@ trait MultilineTablesParser extends PrimitiveRules {
         }.
         filter(_.nonEmpty).
         map(_.map(_.trim))).
-    transpose(_.flatten).
-    reverse.
-    map(_.reduce(_+"\r\n"+_))
+      transpose(_.flatten).
+      reverse.
+      map(_.reduce(_ + EOL + _))
 
     cells
   }
@@ -87,10 +91,10 @@ trait MultilineTablesParser extends PrimitiveRules {
   /**
     * Splits body content into cells using 'width separator'
     * @param sep width separator string, '-- --- --'
-    * @param contents raw contents of the table to be split into cells; blank lines are split points
-    * @return vector of collumns containing cells.
+    * @param contents raw contents of the table body to be split into cells; blank lines are split points
+    * @return vector of columns containing cells.
     */
-  private def parseBodyContent(sep:String, contents: Seq[String]): (Vector[List[String]], String) = {
+  private def parseBodyContent(sep: String, contents: Seq[String]): (Vector[List[String]], String) = {
     def isEmptyString(input: String) = {
       new PrimitvePaserHelper(input).blankLine.run() match {
         case Success(_) => true
@@ -132,12 +136,12 @@ trait MultilineTablesParser extends PrimitiveRules {
               }
           }.filter(_ != "").reverse :: acc
       }).
-      transpose(_.transpose.map(_.reverse.reduce(_ + "\r\n" + _)).toVector).
+      transpose(_.transpose.map(_.reverse.reduce(_ + EOL + _)).toVector).
       toVector
     (cells, widths)
   }
 
-  // ToDo investigate hot to re-use parser on differen inputs in order to avoid creation of a new parser on every line
+  // ToDo investigate hot to re-use parser on different inputs in order to avoid creation of a new parser on every line
   // needed to facilitate some internal processing
   private class PrimitvePaserHelper(val input:ParserInput) extends Parser with PrimitiveRules
 }

--- a/src/main/scala/com/mdpeg/MultilineTablesParser.scala
+++ b/src/main/scala/com/mdpeg/MultilineTablesParser.scala
@@ -5,6 +5,9 @@ trait MultilineTablesParser extends PrimitiveRules {
   this: Parser =>
   import CharPredicate._
 
+  def multiTable = ???
+  def tableBorder: Rule0 = rule(!horizontalRule ~ (3 to 150).times("-") ~ nl)
+
 /* ToDo think about
 * 1. capturing relative width of columns
 * 2. capturing table caption

--- a/src/main/scala/com/mdpeg/MultilineTablesParser.scala
+++ b/src/main/scala/com/mdpeg/MultilineTablesParser.scala
@@ -16,51 +16,11 @@ trait MultilineTablesParser extends PrimitiveRules {
     rule(tableBorder ~ capture(contents) ~ &(tableHeadWidthSeparator) ~> ((y:Seq[String],_:Any) => y.toVector))
   }
 
-  def tableBodyRaw: Rule1[Vector[String]] = {
+  def tableBodyRaw: Rule1[Vector[List[String]]] = {
     def bodyContentLine = rule(capture(atomic(!tableBorder ~ anyLine | blankLine)))
     def contents = rule(bodyContentLine.+)
-    def parseBodyContent(sep:String, contents: Seq[String]) = {
-      def isEmptyString(input:String) = {
-        new PrimitvePaserHelper(input).blankLine.run() match {
-          case Success(_) => true
-          case _ => false
-        }
-      }
-
-      // ToDo scan through to determine positions of every width separator
-      val widths = sep.replaceAll("\r","").replace("\n","")
-      val rows = contents.foldLeft(List.empty[List[String]]) {
-        case (acc, currentLine) =>
-          val isEmptyLine = isEmptyString(currentLine)
-          acc match {
-            case x :: _ if isEmptyLine && x.isEmpty => acc
-            case _ :: _ if isEmptyLine => List.empty[String] :: acc
-            case x :: xs => (x :+ currentLine) :: xs
-            case Nil => List(currentLine) :: Nil
-          }
-      }.reverse
-
-      val cells = rows
-        .map(_.map(_.zip(widths).toList))
-        .map(_.foldLeft(List.empty[List[String]]) {
-          case (acc, currentLine) =>
-            currentLine.foldLeft(List.empty[String]) {
-              case (acc1, cl) =>
-                (acc1,cl) match {
-                case (x::xs, (c, '-')) => (x + c.toString) :: xs
-                case (xs, (_, ' ')) => "" :: xs
-                case (Nil, (c, '-')) => c.toString :: Nil
-                case _ => Nil
-            }
-          }.filter(_!="").reverse :: acc
-        })
-        .transpose(_.transpose.map(_.reverse.reduce(_.trim+"\r\n"+_.trim)))
-      //todo use smtng else instead of \r\n?
-
-      contents.toVector
-    }
-
-    rule(capture(tableHeadWidthSeparator) ~ capture(contents) ~> ((sep:String, contents: Seq[String], _: Any) => parseBodyContent(sep, contents)))
+    rule(capture(tableHeadWidthSeparator) ~ capture(contents) ~>
+      ((sep:String, contents: Seq[String], _: Any) => parseBodyContent(sep, contents)))
   }
 
   // ToDO in case of 1 column it can't be distinguished from tableBorder rule, so no !tableBorder applied here yet
@@ -71,14 +31,58 @@ trait MultilineTablesParser extends PrimitiveRules {
   //aux rules
   private def dashes: Rule0 = rule((3 to 150).times("-"))
 
+  //aux functions
 
+  /**
+    * Splits body content into cells using 'width separator'
+    * @param sep width separator string, '-- --- --'
+    * @param contents raw contents of the table to be split into cells; blank lines are split points
+    * @return vector of collumns containing cells.
+    */
+  private def parseBodyContent(sep:String, contents: Seq[String]): Vector[List[String]] = {
+    def isEmptyString(input: String) = {
+      new PrimitvePaserHelper(input).blankLine.run() match {
+        case Success(_) => true
+        case _ => false
+      }
+    }
+    //'width separator', that is '---- -- --' string
+    val widths = sep.replaceAll("\r", "").replace("\n", "")
+
+    //split into rows by blank lines
+    val rows = contents.foldLeft(List.empty[List[String]]) {
+      case (acc, currentLine) =>
+        val isEmptyLine = isEmptyString(currentLine)
+        val cl = currentLine.replaceAll("\r", "").replace("\n", "")
+        acc match {
+          case x :: _ if isEmptyLine && x.isEmpty => acc
+          case _ :: _ if isEmptyLine => List.empty[String] :: acc
+          case x :: xs => (x :+ cl) :: xs
+          case Nil => List(cl) :: Nil
+        }
+    }.reverse
+
+    //split rows into cells by zipping every row with a 'width separator' and split upon every space it thereof
+    val cells: Vector[List[String]] = rows
+      .map(_.map(_.zip(widths).toList))
+      .map(_.foldLeft(List.empty[List[String]]) {
+        case (acc, currentLine) =>
+          currentLine.foldLeft(List.empty[String]) {
+            case (acc1, cl) =>
+              (acc1, cl) match {
+                case (x :: xs, (c, '-')) => (x + c.toString) :: xs
+                case (x :: xs, (_, ' ')) => "" :: x.trim :: xs
+                case (Nil, (c, '-')) => c.toString :: Nil
+                case _ => Nil
+              }
+          }.filter(_ != "").reverse :: acc
+      })
+      .transpose(_.transpose.map(_.reverse.reduce(_ + "\r\n" + _)).toVector)
+      .toVector
+    cells
+  }
 
   // ToDo investigate hot to re-use parser on differen inputs in order to avoid creation of a new parser on every line
   // needed to facilitate some internal processing
   private class PrimitvePaserHelper(val input:ParserInput) extends Parser with PrimitiveRules
-
-  /* ToDo think about
-* 1. capturing relative width of columns
-* 2. rows are separated by blank lines
-*/
 }

--- a/src/main/scala/com/mdpeg/MultilineTablesParser.scala
+++ b/src/main/scala/com/mdpeg/MultilineTablesParser.scala
@@ -28,17 +28,17 @@ trait MultilineTablesParser extends PrimitiveRules {
       // ToDo scan through to determine positions of every width separator
       val widths = sep.split(' ').filter(_ != "").map(_.replaceAll("\r","").replace("\n","")).toVector
 
-      //ToDo filter out empty entries that might occur in case there're more than 2 empty lines in a row
       val rows = contents.foldLeft(List.empty[List[String]]) {
         case (acc, currentLine) =>
-          if(isEmptyString(currentLine))
-            List.empty[String] :: acc
-          else
-            acc match {
-              case x::xs => (x :+ currentLine) :: xs
-              case Nil => List(currentLine) :: Nil
-            }
-      }
+          val isEmptyLine = isEmptyString(currentLine)
+          acc match {
+            case x :: _ if isEmptyLine && x.isEmpty => acc
+            case _ :: _ if isEmptyLine => List.empty[String] :: acc
+            case x :: xs => (x :+ currentLine) :: xs
+            case Nil => List(currentLine) :: Nil
+          }
+      }.reverse
+
       contents.toVector
     }
 

--- a/src/main/scala/com/mdpeg/MultilineTablesParser.scala
+++ b/src/main/scala/com/mdpeg/MultilineTablesParser.scala
@@ -7,7 +7,7 @@ trait MultilineTablesParser extends PrimitiveRules {
 
   def multiTable = ???
 
-  def tableHead: Rule1[String] = rule(tableBorder ~ capture(anyChar.+) ~ nl ~ tableHeadWidthSeparator)
+  def tableHead: Rule1[String] = rule(tableBorder ~ capture((blankLine | anyLine)) ~ tableHeadWidthSeparator)
   // ToDO in case of 1 column it can't be distinguished from tableBorder rule, so no !tableBorder applied here yet
   def tableHeadWidthSeparator:Rule0 = rule(!horizontalRule ~ ((3 to 150).times("-") ~ sp.*).+ ~ nl.?)
   def tableBorder: Rule0 = rule(!horizontalRule ~ (3 to 150).times("-") ~ nl)

--- a/src/main/scala/com/mdpeg/MultilineTablesParser.scala
+++ b/src/main/scala/com/mdpeg/MultilineTablesParser.scala
@@ -97,21 +97,25 @@ trait MultilineTablesParser extends PrimitiveRules {
         case _ => false
       }
     }
+
     //'width separator', that is '---- -- --' string
     val widths = sep.replaceAll("\r", "").replace("\n", "")
 
     //split into rows by blank lines
-    val rows = contents.foldLeft(List.empty[List[String]]) {
-      case (acc, currentLine) =>
-        val isEmptyLine = isEmptyString(currentLine)
-        val cl = currentLine.replaceAll("\r", "").replace("\n", "")
-        acc match {
-          case x :: _ if isEmptyLine && x.isEmpty => acc
-          case _ :: _ if isEmptyLine => List.empty[String] :: acc
-          case x :: xs => (x :+ cl) :: xs
-          case Nil => List(cl) :: Nil
-        }
-    }.reverse
+    val rows = contents.
+      foldLeft(List.empty[List[String]]) {
+        case (acc, currentLine) =>
+          val isEmptyLine = isEmptyString(currentLine)
+          val cl = currentLine.replaceAll("\r", "").replace("\n", "")
+          acc match {
+            case x :: _ if isEmptyLine && x.isEmpty => acc
+            case _ :: _ if isEmptyLine => List.empty[String] :: acc
+            case x :: xs => (x :+ cl) :: xs
+            case Nil => List(cl) :: Nil
+          }
+      }.
+      reverse.
+      filter(_.nonEmpty)
 
     //split rows into cells by zipping every row with a 'width separator' and split upon every space it thereof
     val cells: Vector[List[String]] = rows.

--- a/src/main/scala/com/mdpeg/MultilineTablesParser.scala
+++ b/src/main/scala/com/mdpeg/MultilineTablesParser.scala
@@ -3,11 +3,14 @@ package com.mdpeg
 import org.parboiled2._
 trait MultilineTablesParser extends PrimitiveRules {
   this: Parser =>
-  import CharPredicate._
 
   def multiTable = ???
 
-  def tableHead: Rule1[String] = rule(tableBorder ~ capture((blankLine | anyLine)) ~ tableHeadWidthSeparator)
+  def tableHead: Rule1[String] = {
+    def headContentLine = rule(!tableHeadWidthSeparator ~ anyLine | blankLine)
+    rule(tableBorder ~ capture(headContentLine.+) ~ tableHeadWidthSeparator)
+  }
+
   // ToDO in case of 1 column it can't be distinguished from tableBorder rule, so no !tableBorder applied here yet
   def tableHeadWidthSeparator:Rule0 = rule(!horizontalRule ~ ((3 to 150).times("-") ~ sp.*).+ ~ nl.?)
   def tableBorder: Rule0 = rule(!horizontalRule ~ (3 to 150).times("-") ~ nl)

--- a/src/main/scala/com/mdpeg/MultilineTablesParser.scala
+++ b/src/main/scala/com/mdpeg/MultilineTablesParser.scala
@@ -1,0 +1,8 @@
+package com.mdpeg
+
+import org.parboiled2._
+trait MultilineTablesParser extends PrimitiveRules {
+  this: Parser =>
+  import CharPredicate._
+
+}

--- a/src/main/scala/com/mdpeg/package.scala
+++ b/src/main/scala/com/mdpeg/package.scala
@@ -1,0 +1,5 @@
+package com
+package object mdpeg {
+  type MultilineTableColumn = Vector[MultilineTableCell]
+  type MultilineTableRow = Vector[MultilineTableCell]
+}

--- a/src/test/scala/MultilineTablesParserSpec.scala
+++ b/src/test/scala/MultilineTablesParserSpec.scala
@@ -1,0 +1,9 @@
+import com.mdpeg.MultilineTablesParser
+import org.parboiled2.{Parser, ParserInput}
+import org.scalatest.{FlatSpec, Matchers}
+
+class MultilineTablesParserSpec extends FlatSpec with Matchers  {
+  class MultilineTablesParserTestSpec(val input: ParserInput) extends Parser with MultilineTablesParser {}
+
+
+}

--- a/src/test/scala/MultilineTablesParserSpec.scala
+++ b/src/test/scala/MultilineTablesParserSpec.scala
@@ -47,7 +47,7 @@ class MultilineTablesParserSpec extends FlatSpec with Matchers {
         |Term 1                Description line 1
         |----------------      ------------------------------------------------
         |""".stripMargin
-    val parsed = new MultilineTablesParserTestSpec(term).tableHead.run()
+    val parsed = new MultilineTablesParserTestSpec(term).tableHeadRaw.run()
     noException should be thrownBy { parsed.get }
   }
 
@@ -62,7 +62,7 @@ class MultilineTablesParserSpec extends FlatSpec with Matchers {
         |Term 4                Description line 4
         |----------------      ------------------------------------------------
         |""".stripMargin
-    val parsed = new MultilineTablesParserTestSpec(term).tableHead.run()
+    val parsed = new MultilineTablesParserTestSpec(term).tableHeadRaw.run()
     noException should be thrownBy { parsed.get }
   }
 
@@ -71,7 +71,24 @@ class MultilineTablesParserSpec extends FlatSpec with Matchers {
       """--------------------------------------------------------------------------------
         |----------------      ------------------------------------------------
         |""".stripMargin
-    val parsed = new MultilineTablesParserTestSpec(term).tableHead.run()
+    val parsed = new MultilineTablesParserTestSpec(term).tableHeadRaw.run()
     a [ParseError] should be thrownBy { parsed.get }
+  }
+
+  it should "parse table content for table without head" in {
+    val term =
+      """-----------           --------------------
+        |.It 1                 is a long established fact that 1
+        |.It 2                 is a long established fact that 2
+        |.It 3                 is a long established fact that 3
+        |
+        |CAPSED WORD 1         The point of using Lorem Ipsum is 1
+        |CAPSED WORD 2         The point of using Lorem Ipsum is 2
+        |
+        |Many                  desktop publishing packages and
+        |--------------------------------------------------------
+        |""".stripMargin
+    val parsed = new MultilineTablesParserTestSpec(term).tableBodyRaw.run()
+    noException should be thrownBy { parsed.get }
   }
 }

--- a/src/test/scala/MultilineTablesParserSpec.scala
+++ b/src/test/scala/MultilineTablesParserSpec.scala
@@ -1,4 +1,4 @@
-import com.mdpeg.MultilineTablesParser
+import com.mdpeg._
 import com.mdpeg.Parser.parser
 import org.parboiled2.{ErrorFormatter, ParseError, Parser, ParserInput}
 import org.scalatest.{FlatSpec, Matchers}
@@ -106,12 +106,21 @@ class MultilineTablesParserSpec extends FlatSpec with Matchers {
         |--------------------------------------------------------------------------------
         |Table: This is a table caption\label{table:table_lable_name}""".stripMargin
     val parser = new MultilineTablesParserTestSpec(term)
-    parser.multiTable.run() match {
-      case Success(node) => println(node)
-      case Failure(e: ParseError) =>
-        println(parser.formatError(e, new ErrorFormatter(showTraces = true)))
-      case Failure(e) =>
-        throw e
-    }
+    parser.multiTable.run().get shouldEqual MultilineTableBlock(
+      Vector(25.0f, 75.0f),
+      Some(MultilineTableCaption(Markdown("This is a table caption\\label{table:table_lable_name}"))),
+      Some(Vector(
+        MultilineTableCell(Markdown("""Term  1
+                                      |Term  cont""".stripMargin)),
+        MultilineTableCell(Markdown("""Description 1
+                                      |Description cont""".stripMargin)))),
+      Vector(Vector(
+        MultilineTableCell(Markdown(".It")),
+        MultilineTableCell(Markdown("CAPSED WORD")),
+        MultilineTableCell(Markdown("Many"))),
+      Vector(
+        MultilineTableCell(Markdown("is a long established fact that")),
+        MultilineTableCell(Markdown("The point of using Lorem Ipsum is")),
+        MultilineTableCell(Markdown("desktop publishing packages and")))))
   }
 }

--- a/src/test/scala/MultilineTablesParserSpec.scala
+++ b/src/test/scala/MultilineTablesParserSpec.scala
@@ -47,12 +47,31 @@ class MultilineTablesParserSpec extends FlatSpec with Matchers {
         |Term 1                Description line 1
         |----------------      ------------------------------------------------
         |""".stripMargin
-    //     val parsed = new MultilineTablesParserTestSpec(term).tableHead.run()
-    //     noException should be thrownBy { parsed.get }
-    new MultilineTablesParserTestSpec(term).tableHead.run() match {
-      case Success(node) => println(node)
-      case Failure(e: ParseError) => println(parser.formatError(e, new ErrorFormatter(showTraces = true)))
-      case Failure(e) => throw e
-    }
+    val parsed = new MultilineTablesParserTestSpec(term).tableHead.run()
+    noException should be thrownBy { parsed.get }
+  }
+
+  it should "parse table a multi-line tall heading with blank lines" in {
+    val term =
+      """--------------------------------------------------------------------------------
+        |Term 1                Description line 1
+        |Term 2                Description line 2
+        |
+        |Term 3                Description line 3
+        |
+        |Term 4                Description line 4
+        |----------------      ------------------------------------------------
+        |""".stripMargin
+    val parsed = new MultilineTablesParserTestSpec(term).tableHead.run()
+    noException should be thrownBy { parsed.get }
+  }
+
+  it should "fail parsing table with no content lines" in {
+    val term =
+      """--------------------------------------------------------------------------------
+        |----------------      ------------------------------------------------
+        |""".stripMargin
+    val parsed = new MultilineTablesParserTestSpec(term).tableHead.run()
+    a [ParseError] should be thrownBy { parsed.get }
   }
 }

--- a/src/test/scala/MultilineTablesParserSpec.scala
+++ b/src/test/scala/MultilineTablesParserSpec.scala
@@ -44,7 +44,7 @@ class MultilineTablesParserSpec extends FlatSpec with Matchers {
   it should "parse table a one-line tall heading" in {
     val term =
       """--------------------------------------------------------------------------------
-        |Term                  Description
+        |Term 1                Description line 1
         |----------------      ------------------------------------------------
         |""".stripMargin
     //     val parsed = new MultilineTablesParserTestSpec(term).tableHead.run()

--- a/src/test/scala/MultilineTablesParserSpec.scala
+++ b/src/test/scala/MultilineTablesParserSpec.scala
@@ -77,7 +77,7 @@ class MultilineTablesParserSpec extends FlatSpec with Matchers {
 
   it should "parse table content for table without head" in {
     val term =
-      """-----------           --------------------
+      """----------------      ------------------------------------------------
         |.It 1                 is a long established fact that 1
         |.It 2                 is a long established fact that 2
         |.It 3                 is a long established fact that 3
@@ -86,8 +86,7 @@ class MultilineTablesParserSpec extends FlatSpec with Matchers {
         |CAPSED WORD 2         The point of using Lorem Ipsum is 2
         |
         |Many                  desktop publishing packages and
-        |--------------------------------------------------------
-        |""".stripMargin
+        """.stripMargin
     val parsed = new MultilineTablesParserTestSpec(term).tableBodyRaw.run()
     noException should be thrownBy { parsed.get }
   }

--- a/src/test/scala/MultilineTablesParserSpec.scala
+++ b/src/test/scala/MultilineTablesParserSpec.scala
@@ -94,7 +94,9 @@ class MultilineTablesParserSpec extends FlatSpec with Matchers {
   it should "parser table with header and caption" in {
     val term =
       """--------------------------------------------------------------------------------
-        |Term                  Description
+        |Term  1               Description 1
+        |
+        |Term  cont            Description cont
         |----------------      ------------------------------------------------
         |.It                   is a long established fact that
         |

--- a/src/test/scala/MultilineTablesParserSpec.scala
+++ b/src/test/scala/MultilineTablesParserSpec.scala
@@ -24,7 +24,9 @@ class MultilineTablesParserSpec extends FlatSpec with Matchers {
   )
 
   it should "parse table border" in {
-    val parsed = new MultilineTablesParserTestSpec("-------------------------------------------------------------------------------\r\n").tableBorder.run()
+    val term ="""-------------------------------------------------------------------------------
+      |""".stripMargin
+    val parsed = new MultilineTablesParserTestSpec(term).tableBorder.run()
     noException should be thrownBy {
       parsed.get
     }
@@ -148,10 +150,14 @@ class MultilineTablesParserSpec extends FlatSpec with Matchers {
     parser.multiTable.run().get shouldEqual tableMock(Vector(
       Vector(
         MultilineTableCell(Markdown(".It")),
-        MultilineTableCell(Markdown("CAPSED WORD\r\nMany"))),
+        MultilineTableCell(Markdown(
+          """CAPSED WORD
+            |Many""".stripMargin))),
       Vector(
         MultilineTableCell(Markdown("is a long established fact that")),
-        MultilineTableCell(Markdown("The point of using Lorem Ipsum is\r\ndesktop publishing packages and")))))
+        MultilineTableCell(Markdown(
+          """The point of using Lorem Ipsum is
+            |desktop publishing packages and""".stripMargin)))))
   }
 
   it should "eleminate trailing empty line in body row" in {

--- a/src/test/scala/MultilineTablesParserSpec.scala
+++ b/src/test/scala/MultilineTablesParserSpec.scala
@@ -10,16 +10,18 @@ class MultilineTablesParserSpec extends FlatSpec with Matchers {
   class MultilineTablesParserTestSpec(val input: ParserInput) extends Parser with MultilineTablesParser {
   }
 
-  def tableMock(bodyColumns: Vector[MultilineTableColumn]) = MultilineTableBlock(
-    Vector(25.0f, 75.0f),
+  def tableMock(bodyColumns: Vector[MultilineTableColumn],
+                head: Option[MultilineTableRow] = Some(Vector(
+                  MultilineTableCell(Markdown(
+                    """Term  1
+                      |Term  cont""".stripMargin)),
+                  MultilineTableCell(Markdown(
+                    """Description 1
+                      |Description cont""".stripMargin)))),
+                widths: Vector[Float] = Vector(25.0f, 75.0f)) = MultilineTableBlock(
+    widths,
     Some(MultilineTableCaption(Markdown("This is a table caption\\label{table:table_lable_name}"))),
-    Some(Vector(
-      MultilineTableCell(Markdown(
-        """Term  1
-          |Term  cont""".stripMargin)),
-      MultilineTableCell(Markdown(
-        """Description 1
-          |Description cont""".stripMargin)))),
+    head,
     bodyColumns
   )
 
@@ -180,5 +182,24 @@ class MultilineTablesParserSpec extends FlatSpec with Matchers {
       Vector(
         MultilineTableCell(Markdown("is a long established fact that"))
     )))
+  }
+
+  it should "parse 1x1 table with header" in {
+    val term =
+      """--------------------------------------------------------------------------------
+        |Term  1
+        |
+        |Term  cont
+        |----------------
+        |.It
+        |
+        |--------------------------------------------------------------------------------
+        |Table: This is a table caption\label{table:table_lable_name}""".stripMargin
+    val parser = new MultilineTablesParserTestSpec(term)
+    parser.multiTable.run().get shouldEqual tableMock(Vector(
+      Vector(MultilineTableCell(Markdown(".It")))), Some(Vector(
+      MultilineTableCell(Markdown(
+        """Term  1
+          |Term  cont""".stripMargin)))), Vector(100.0f))
   }
 }

--- a/src/test/scala/MultilineTablesParserSpec.scala
+++ b/src/test/scala/MultilineTablesParserSpec.scala
@@ -2,11 +2,20 @@ import com.mdpeg.MultilineTablesParser
 import org.parboiled2.{Parser, ParserInput}
 import org.scalatest.{FlatSpec, Matchers}
 
-class MultilineTablesParserSpec extends FlatSpec with Matchers  {
+class MultilineTablesParserSpec extends FlatSpec with Matchers {
+
   class MultilineTablesParserTestSpec(val input: ParserInput) extends Parser with MultilineTablesParser {}
 
   it should "parse table border" in {
     val parsed = new MultilineTablesParserTestSpec("-------------------------------------------------------------------------------\r\n").tableBorder.run()
+    noException should be thrownBy {
+      parsed.get
+    }
+  }
+
+  it should "parse table caption" in {
+    val term: String = """Table: This is a table caption\\label{table:table_lable_name}"""
+    val parsed = new MultilineTablesParserTestSpec(term).tableCaption.run()
     noException should be thrownBy { parsed.get }
   }
 }

--- a/src/test/scala/MultilineTablesParserSpec.scala
+++ b/src/test/scala/MultilineTablesParserSpec.scala
@@ -99,11 +99,11 @@ class MultilineTablesParserSpec extends FlatSpec with Matchers {
         |CAPSED WORD 2         The point of using Lorem Ipsum is 2
         |
         |Many                  desktop publishing packages and""".stripMargin
-    val parsed = new MultilineTablesParserTestSpec(term).tableBodyRaw.run()
+    val parsed = new MultilineTablesParserTestSpec(term).tableBody.run()
     noException should be thrownBy { parsed.get }
   }
 
-  it should "parser table with header and caption" in {
+  it should "parse table with header and caption" in {
     val term =
       """--------------------------------------------------------------------------------
         |Term  1               Description 1

--- a/src/test/scala/MultilineTablesParserSpec.scala
+++ b/src/test/scala/MultilineTablesParserSpec.scala
@@ -85,8 +85,7 @@ class MultilineTablesParserSpec extends FlatSpec with Matchers {
         |CAPSED WORD 1         The point of using Lorem Ipsum is 1
         |CAPSED WORD 2         The point of using Lorem Ipsum is 2
         |
-        |Many                  desktop publishing packages and
-        """.stripMargin
+        |Many                  desktop publishing packages and""".stripMargin
     val parsed = new MultilineTablesParserTestSpec(term).tableBodyRaw.run()
     noException should be thrownBy { parsed.get }
   }

--- a/src/test/scala/MultilineTablesParserSpec.scala
+++ b/src/test/scala/MultilineTablesParserSpec.scala
@@ -1,10 +1,14 @@
 import com.mdpeg.MultilineTablesParser
-import org.parboiled2.{Parser, ParserInput}
+import com.mdpeg.Parser.parser
+import org.parboiled2.{ErrorFormatter, ParseError, Parser, ParserInput}
 import org.scalatest.{FlatSpec, Matchers}
+
+import scala.util.{Failure, Success}
 
 class MultilineTablesParserSpec extends FlatSpec with Matchers {
 
-  class MultilineTablesParserTestSpec(val input: ParserInput) extends Parser with MultilineTablesParser {}
+  class MultilineTablesParserTestSpec(val input: ParserInput) extends Parser with MultilineTablesParser {
+  }
 
   it should "parse table border" in {
     val parsed = new MultilineTablesParserTestSpec("-------------------------------------------------------------------------------\r\n").tableBorder.run()
@@ -14,8 +18,41 @@ class MultilineTablesParserSpec extends FlatSpec with Matchers {
   }
 
   it should "parse table caption" in {
-    val term: String = """Table: This is a table caption\\label{table:table_lable_name}"""
+    val term = """Table: This is a table caption\\label{table:table_lable_name}"""
     val parsed = new MultilineTablesParserTestSpec(term).tableCaption.run()
     noException should be thrownBy { parsed.get }
+  }
+
+  it should "parse table's width separator" in {
+    val term =
+        """-----------                       ---------------------------------
+          |""".stripMargin
+    val term2 =
+      """-----------  ---  --- --- --- --- ---   -------  ------ ---------------------------------
+        |""".stripMargin
+    val term3 =
+      """-----------
+        |""".stripMargin
+    val parsed = new MultilineTablesParserTestSpec(term).tableHeadWidthSeparator.run()
+    val parsed2 = new MultilineTablesParserTestSpec(term2).tableHeadWidthSeparator.run()
+    val parsed3 = new MultilineTablesParserTestSpec(term3).tableHeadWidthSeparator.run()
+    noException should be thrownBy { parsed.get }
+    noException should be thrownBy { parsed2.get }
+    noException should be thrownBy { parsed3.get }
+  }
+
+  it should "parse table a one-line tall heading" in {
+    val term =
+      """--------------------------------------------------------------------------------
+        |Term                  Description
+        |----------------      ------------------------------------------------
+        |""".stripMargin
+    //     val parsed = new MultilineTablesParserTestSpec(term).tableHead.run()
+    //     noException should be thrownBy { parsed.get }
+    new MultilineTablesParserTestSpec(term).tableHead.run() match {
+      case Success(node) => println(node)
+      case Failure(e: ParseError) => println(parser.formatError(e, new ErrorFormatter(showTraces = true)))
+      case Failure(e) => throw e
+    }
   }
 }

--- a/src/test/scala/MultilineTablesParserSpec.scala
+++ b/src/test/scala/MultilineTablesParserSpec.scala
@@ -91,4 +91,26 @@ class MultilineTablesParserSpec extends FlatSpec with Matchers {
     val parsed = new MultilineTablesParserTestSpec(term).tableBodyRaw.run()
     noException should be thrownBy { parsed.get }
   }
+
+  it should "parser table with header and caption" in {
+    val term =
+      """--------------------------------------------------------------------------------
+        |Term                  Description
+        |----------------      ------------------------------------------------
+        |.It                   is a long established fact that
+        |
+        |CAPSED WORD           The point of using Lorem Ipsum is
+        |
+        |Many                  desktop publishing packages and
+        |--------------------------------------------------------------------------------
+        |Table: This is a table caption\label{table:table_lable_name}""".stripMargin
+    val parser = new MultilineTablesParserTestSpec(term)
+    parser.multiTable.run() match {
+      case Success(node) => println(node)
+      case Failure(e: ParseError) =>
+        println(parser.formatError(e, new ErrorFormatter(showTraces = true)))
+      case Failure(e) =>
+        throw e
+    }
+  }
 }

--- a/src/test/scala/MultilineTablesParserSpec.scala
+++ b/src/test/scala/MultilineTablesParserSpec.scala
@@ -82,6 +82,7 @@ class MultilineTablesParserSpec extends FlatSpec with Matchers {
         |.It 2                 is a long established fact that 2
         |.It 3                 is a long established fact that 3
         |
+        |
         |CAPSED WORD 1         The point of using Lorem Ipsum is 1
         |CAPSED WORD 2         The point of using Lorem Ipsum is 2
         |

--- a/src/test/scala/MultilineTablesParserSpec.scala
+++ b/src/test/scala/MultilineTablesParserSpec.scala
@@ -5,5 +5,8 @@ import org.scalatest.{FlatSpec, Matchers}
 class MultilineTablesParserSpec extends FlatSpec with Matchers  {
   class MultilineTablesParserTestSpec(val input: ParserInput) extends Parser with MultilineTablesParser {}
 
-
+  it should "parse table border" in {
+    val parsed = new MultilineTablesParserTestSpec("-------------------------------------------------------------------------------\r\n").tableBorder.run()
+    noException should be thrownBy { parsed.get }
+  }
 }


### PR DESCRIPTION
# Multiline tables support
## Summary
- Added support for multiline tables extension (for reference [see](http://pandoc.org/MANUAL.html#tables) -- "Extension: multiline_tables"). 
- The only difference is that a table caption should not be separated from the table's body by a blank line.
- Wrote tests for the MultilineTableParser trait.

## Example
For the table like the following
```
--------------------------------------------------------------------------------
Term  1       Term  2       Term  3       Term  4      Term  5
-----------   -----------   -----------   -----------  -----------
.It           is             a            rectangular  table
--------------------------------------------------------------------------------
Table: This is a table caption\label{table:table_lable_name}
```
AST has the following form
``` scala
MultilineTableBlock(
      Vector(20.0f, 20.0f, 20.0f, 20.0f, 20.0f), //relative column widths
      //caption
      Some(MultilineTableCaption(Markdown("This is a table caption\\label{table:table_lable_name}"))),
     //header row
      Some(
        Vector(
          MultilineTableCell(Markdown("Term  1")),
          MultilineTableCell(Markdown("Term  2")),
          MultilineTableCell(Markdown("Term  3")),
          MultilineTableCell(Markdown("Term  4")),
          MultilineTableCell(Markdown("Term  5")))),
      //body columns
      Vector(
        Vector(MultilineTableCell(Markdown(".It"))),
        Vector(MultilineTableCell(Markdown("is"))),
        Vector(MultilineTableCell(Markdown("a"))),
        Vector(MultilineTableCell(Markdown("rectangular"))),
        Vector(MultilineTableCell(Markdown("table")))))
```
## Further development
- Add support for different types of text alignement in a table column (left, center, right).
- Improve routine that calculates relative column width (as of current implementation -- it won't sum up to 100% for every configuration of column widths).
- There's defenitely should be a way of re-using a parboiled2's Parser upon differn inputs, that is -- blank line split routine should be optimized (the one that split table body into rows).