### PR TITLE
Inline code verbatim suppor

### DIFF
--- a/src/main/scala/com/mdpeg/Inline.scala
+++ b/src/main/scala/com/mdpeg/Inline.scala
@@ -1,6 +1,7 @@
 package com.mdpeg
 
 sealed trait Inline
+case class Code(inline: Any) extends Inline
 case class Image(inline: Seq[Inline], target: Target, width: Option[Int]) extends Inline
 case class Strong(inline: Seq[Inline]) extends Inline
 case class Italics(inline: Seq[Inline]) extends Inline

--- a/src/main/scala/com/mdpeg/InlineRules.scala
+++ b/src/main/scala/com/mdpeg/InlineRules.scala
@@ -6,7 +6,7 @@ trait InlineRules {
   this: Parser with PrimitiveRules =>
   import CharPredicate._
 
-  def inline:  Rule1[Inline] = rule(strong | italics | endLine | spaces | link | image | autolink | text)
+  def inline:  Rule1[Inline] = rule(strong | italics | code | endLine | spaces | link | image | autolink | text)
 
   def text:     Rule1[Text]       = rule(capture(textChar.+) ~> Text)
   def endLine:  Rule1[Space.type] = rule(capture(" ".? ~ nl ~ !blankLine ~ !EOI) ~> ((_:String) => Space))

--- a/src/main/scala/com/mdpeg/InlineRules.scala
+++ b/src/main/scala/com/mdpeg/InlineRules.scala
@@ -15,8 +15,7 @@ trait InlineRules {
   def italics:  Rule1[Italics]    = rule(italicsStarred | italicsUnderlined)
   def link:     Rule1[Link]       = rule(explicitLink | referenceLink)
   def autolink: Rule1[Link]       = rule(autolinkUri | autolinkEmail)
-
-  def image: Rule1[Image] = {
+  def image:    Rule1[Image] = {
     def width: Rule1[Int] = rule("{" ~ sps ~ ("width"|"WIDTH") ~ sps ~ "=" ~ sps ~ capture(Digit.+) ~ "%" ~ sps ~ "}" ~> ((w:String) => w.toInt))
     /*_*/
     rule("!" ~ link ~ sps ~ width.? ~> ((l: Link, w:Option[Int]) => l match {
@@ -24,6 +23,14 @@ trait InlineRules {
       case _ => sys.error("Error trying convert Link to image in patter matching expression.")
     }))
     /*_*/
+  }
+  def code:     Rule1[Code] = {
+    def ticks: Int => Rule0 = (n:Int) => rule{n.times("`") ~ !"`"}
+    def betweenTicks: Int => Rule1[String] = (n:Int) => rule{ticks(n) ~ capture((noneOf("`").+ | !ticks(n) ~ oneOrMore("`")).+) ~ ticks(n)}
+    rule{&("`") ~ (betweenTicks(10) | betweenTicks(9)| betweenTicks(8)| betweenTicks(7)|
+      betweenTicks(6)| betweenTicks(5)| betweenTicks(4)| betweenTicks(3)| betweenTicks(2)| betweenTicks(1)) ~>
+      ((s:Any)=> Code(s))
+    }
   }
 
   def explicitLink:  Rule1[Link] = {

--- a/src/test/scala/InlineRulesSpec.scala
+++ b/src/test/scala/InlineRulesSpec.scala
@@ -161,4 +161,9 @@ class InlineRulesSpec extends FlatSpec with Matchers {
     val term = "`this is code{}!@#$%^&*()\r\n`"
     new InlineRulesTestSpec(term).code.run().get shouldEqual Code("this is code{}!@#$%^&*()\r\n")
   }
+
+  it should "parse an inline code with 10 ticks" in {
+    val term = "``````````this is code{}!@#$%^&*()\r\n``````````"
+    new InlineRulesTestSpec(term).code.run().get shouldEqual Code("this is code{}!@#$%^&*()\r\n")
+  }
 }

--- a/src/test/scala/InlineRulesSpec.scala
+++ b/src/test/scala/InlineRulesSpec.scala
@@ -159,11 +159,11 @@ class InlineRulesSpec extends FlatSpec with Matchers {
 
   it should "parse an inline code" in {
     val term = "`this is code{}!@#$%^&*()\r\n`"
-    new InlineRulesTestSpec(term).code.run().get shouldEqual Code("this is code{}!@#$%^&*()\r\n")
+    new InlineRulesTestSpec(term).inline.run().get shouldEqual Code("this is code{}!@#$%^&*()\r\n")
   }
 
   it should "parse an inline code with 10 ticks" in {
     val term = "``````````this is code{}!@#$%^&*()\r\n``````````"
-    new InlineRulesTestSpec(term).code.run().get shouldEqual Code("this is code{}!@#$%^&*()\r\n")
+    new InlineRulesTestSpec(term).inline.run().get shouldEqual Code("this is code{}!@#$%^&*()\r\n")
   }
 }

--- a/src/test/scala/InlineRulesSpec.scala
+++ b/src/test/scala/InlineRulesSpec.scala
@@ -147,6 +147,7 @@ class InlineRulesSpec extends FlatSpec with Matchers {
     parser.inline.run().get shouldEqual
       Image(Vector(Text("Image"), Space, Text("label")),Src("src/images/image1.png",None),Some(2000))
   }
+
   it should "parse a reference style image link with width" in {
     val term = "![I'm a reference link][Arbitrary reference text]{ width=1% }"
     val parser = new InlineRulesTestSpec(term)
@@ -154,5 +155,10 @@ class InlineRulesSpec extends FlatSpec with Matchers {
       Image(Vector(Text("I'm"), Space, Text("a"), Space, Text("reference"), Space, Text("link")),
         Ref(Vector(Text("Arbitrary"), Space, Text("reference"), Space, Text("text")),""),
         Some(1))
+  }
+
+  it should "parse an inline code" in {
+    val term = "`this is code{}!@#$%^&*()\r\n`"
+    new InlineRulesTestSpec(term).code.run().get shouldEqual Code("this is code{}!@#$%^&*()\r\n")
   }
 }


### PR DESCRIPTION
**Summary of the changes**

Implemented #9.
- support for inline code such as 

```markdown 
`this is inline code `
```
- added unit tests
- supported number of ticks is 10, that is all in-between 1..10 ticks will be treated as inline code