### PR TITLE
Parse nested Markdown blocks

### DIFF
--- a/src/main/scala/com/mdpeg/ASTTransform.scala
+++ b/src/main/scala/com/mdpeg/ASTTransform.scala
@@ -54,10 +54,7 @@ object ASTTransform {
 
       val transformedHead = head map { head =>
         processMarkdownContainer {
-          head.flatMap { h =>
-            val MultilineTableCell(bs) = h
-            bs
-          }
+          head.flatMap { case MultilineTableCell(bs) => bs }
         }(blocks => Right(Vector(MultilineTableCell(blocks.toVector))))
       }
 
@@ -82,7 +79,9 @@ object ASTTransform {
 
         case (c, h, b) =>
           val cc = c.map(x => MultilineTableCaption(x.right.get.toVector))
-          val hh = h.map(y => Vector(MultilineTableCell(y.right.get.toVector)))
+          val hh = h.map { y =>
+            y.right.get.toVector match { case Vector(MultilineTableCell(cs)) => cs.map((a1: Block) => MultilineTableCell(Vector(a1))) }
+          }
           val bb = b.right.get
           Right(Vector(MultilineTableBlock(relativeWidth, cc, hh, bb)))
       }

--- a/src/main/scala/com/mdpeg/ASTTransform.scala
+++ b/src/main/scala/com/mdpeg/ASTTransform.scala
@@ -1,0 +1,9 @@
+package com.mdpeg
+
+import org.parboiled2.ParseError
+
+object ASTTransform {
+  def transformTree(tree: Seq[Block]): Either[ParseError, Seq[Block]] = {
+    ???
+  }
+}

--- a/src/main/scala/com/mdpeg/ASTTransform.scala
+++ b/src/main/scala/com/mdpeg/ASTTransform.scala
@@ -22,37 +22,49 @@ object ASTTransform {
     }
   }
 
-  def transformNode(b: Block): Either[FailureMessage, Seq[Block]] = {
-    def processContainerWithMarkdown(v:Seq[Block]): Either[FailureMessage, Seq[Block]] = {
-      transformTree(v) match {
-        case Left(t) => Left(t.fold("")(_+EOL+_))
-        case Right(r) => Right(r.flatten)
+  def transformNode(block: Block): Either[Seq[FailureMessage], Seq[Block]] = {
+    def processMarkdownContainer[Container <: Block](v: Seq[Block])(resultMap: Seq[Block] => Either[Nothing, Seq[Container]]) = {
+      def process(v: Seq[Block]) = {
+        transformTree(v) match {
+          case Left(t) => Left(t)
+          case Right(r) =>
+            r.flatten |> transformTree match {
+              case Left(errors) => Left(errors)
+              case Right(blocks) => Right(blocks.flatten)
+            }
+        }
+      }
+
+      process(v) match {
+        case l @ Left(_) => l
+        case Right(blocks) => resultMap(blocks)
       }
     }
 
-    b match {
-      case m @ Markdown(_) =>
-        processMarkdown(m) match {
-          case l @ Left(_) => l
-          case r @ Right(_) => r
-        }
+    def processMarkdownBlock(m: Markdown) = {
+      processMarkdown(m) match {
+        case Left(errors) => Left(Vector(errors))
+        case Right(blocks) => Right(blocks)
+      }
+    }
 
-      case UnorderedList(v) => processContainerWithMarkdown(v)
-      case OrderedList(v) => processContainerWithMarkdown(v)
-      case BlockQuote(v) => processContainerWithMarkdown(v)
-
-      case _  => Right(Vector(b))
+    block match {
+      case m @ Markdown(_) => processMarkdownBlock(m)
+      case UnorderedList(v) => processMarkdownContainer(v)(blocks => Right(Vector(UnorderedList(blocks.toVector))))
+      case OrderedList(v) => processMarkdownContainer(v)(blocks => Right(Vector(OrderedList(blocks.toVector))))
+      case BlockQuote(v) => processMarkdownContainer(v)(blocks => Right(Vector(BlockQuote(blocks.toVector))))
+      case _ => Right(Vector(block))
     }
   }
 
-  def join(parsed: Seq[Either[FailureMessage, Seq[Block]]]): Either[Seq[FailureMessage], Seq[MacroBlock]] = {
+  def join(parsed: Seq[Either[Seq[FailureMessage], Seq[Block]]]): Either[Seq[FailureMessage], Seq[MacroBlock]] = {
     parsed.partition(_.isLeft) match {
-      case(Nil, blocks) =>
-        val mbs: Seq[MacroBlock] = for(Right(i) <- blocks) yield i
+      case (Nil, blocks) =>
+        val mbs: Seq[MacroBlock] = for (Right(i) <- blocks) yield i
         Right(mbs)
-      case(pe, _) =>
-        val pes: Seq[FailureMessage] = for(Left(s) <- pe) yield s
-        Left(pes)
+      case (pe, _) =>
+        val pes: Seq[Seq[FailureMessage]] = for (Left(s) <- pe) yield s
+        Left(pes.flatten)
     }
   }
 

--- a/src/main/scala/com/mdpeg/ASTTransform.scala
+++ b/src/main/scala/com/mdpeg/ASTTransform.scala
@@ -1,8 +1,33 @@
 package com.mdpeg
 
-import org.parboiled2.ParseError
+import org.parboiled2.{ErrorFormatter, ParseError}
+import scala.util.{Failure, Success}
 
 object ASTTransform {
+
+  def processMarkdown(m: Markdown): Either[String, Seq[Block]] = {
+    val Markdown(inline) = m
+    val parser = new BlockParser(inline)
+    parser.InputLine.run() match {
+      case Success(node) => Right(node)
+      case Failure(e: ParseError) =>
+        val error = parser.formatError(e, new ErrorFormatter(showTraces = true))
+        Left(error)
+      case Failure(e) => sys.error(e.getMessage)
+    }
+  }
+
+  def transformNode(b: Block): Either[String, Seq[Block]] = {
+    b match {
+      case m @ Markdown(_) =>
+        processMarkdown(m) match {
+          case l @ Left(_) => l
+          case r @ Right(_) => r
+        }
+      case _  => Right(Vector(b))
+    }
+  }
+
   def transformTree(tree: Seq[Block]): Either[ParseError, Seq[Block]] = {
     ???
   }

--- a/src/main/scala/com/mdpeg/ASTTransform.scala
+++ b/src/main/scala/com/mdpeg/ASTTransform.scala
@@ -23,12 +23,11 @@ object ASTTransform {
   }
 
   def transformNode(b: Block): Either[FailureMessage, Seq[Block]] = {
-    def processContainerWithMarkdown(v:Seq[Block]) = {
-      val tt = transformTree(v)
-      if(tt.isLeft)
-        Left(tt.left.get.fold("")(_+EOL+_))
-      else
-        Right(tt.right.get.flatten)
+    def processContainerWithMarkdown(v:Seq[Block]): Either[FailureMessage, Seq[Block]] = {
+      transformTree(v) match {
+        case Left(t) => Left(t.fold("")(_+EOL+_))
+        case Right(r) => Right(r.flatten)
+      }
     }
 
     b match {

--- a/src/main/scala/com/mdpeg/ASTTransform.scala
+++ b/src/main/scala/com/mdpeg/ASTTransform.scala
@@ -59,19 +59,10 @@ object ASTTransform {
       }
 
       def parseColumn(body: MultilineTableColumn): Either[Seq[FailureMessage], MultilineTableColumn] = {
-        def toColumn(value: Either[Seq[FailureMessage], Seq[Seq[Block]]]): Either[Seq[FailureMessage], Vector[MultilineTableCell]] = {
-          value.map{ (x: Seq[Seq[Block]]) =>
-            x.
-              toVector.
-              map{case Vector(MultilineTableCell(inner)) => inner}.
-              map{case Vector(i) => MultilineTableCell(Vector(i))}
-          }
-        }
-
         body.
-            map { case MultilineTableCell(blocks) => blocks}.
-            map(processMarkdownContainer(_)(blocks => Right(Vector(MultilineTableCell(blocks.toVector))))) |>
-            join |> toColumn
+          map { case MultilineTableCell(blocks) => blocks }.
+          map(processMarkdownContainer(_)(blocks =>Right(Vector(MultilineTableCell(blocks.toVector))))) |>
+          join |> (_.map(_.toVector.map { case Vector(MultilineTableCell(inner)) => MultilineTableCell(inner) }))
       }
 
       val transformedBodyColumns = rawBody.map(parseColumn) |> join |> (_.map(_.map(_.toVector).toVector))

--- a/src/main/scala/com/mdpeg/ASTTransform.scala
+++ b/src/main/scala/com/mdpeg/ASTTransform.scala
@@ -55,8 +55,8 @@ object ASTTransform {
 
       val MultilineTableBlock(relativeWidth, rawCaption, rawHead, rawBody) = mt
       val transformedCaption = rawCaption map { c =>
-        val MultilineTableCaption(md) = c
-        processMarkdownContainer(md)(blocks => Right(Vector(MultilineTableCaption(blocks))))
+        val MultilineTableCaption(md, label) = c
+        processMarkdownContainer(md)(blocks => Right(Vector(MultilineTableCaption(blocks, label))))
       }
 
       val transformedHead = rawHead map { head =>
@@ -73,7 +73,10 @@ object ASTTransform {
         case (_, _, Left(l)) => Left(l)
 
         case (c, h, b) =>
-          val maybeCaption = c.map(x => MultilineTableCaption(x.right.get))
+          val maybeCaption = c.map { x =>
+            val Vector(MultilineTableCaption(blocks, label)) = x.right.get
+            MultilineTableCaption(blocks, label)
+          }
           val maybeHeader = h.map {
             _.right.get match { case Vector(MultilineTableCell(bs)) => bs.map(i => MultilineTableCell(Vector(i))) }
           }

--- a/src/main/scala/com/mdpeg/ASTTransform.scala
+++ b/src/main/scala/com/mdpeg/ASTTransform.scala
@@ -2,12 +2,10 @@ package com.mdpeg
 
 import org.parboiled2.{ErrorFormatter, ParseError}
 
-import scala.collection.immutable
 import scala.util.{Failure, Success}
 
 object ASTTransform {
   type FailureMessage = String
-  type MacroBlock = Seq[Block]
 
   def processMarkdown(m: Markdown): Either[FailureMessage, Seq[Block]] = {
     val Markdown(inline) = m
@@ -47,50 +45,55 @@ object ASTTransform {
       }
     }
 
+    def transformTable(mt: MultilineTableBlock) = {
+      val MultilineTableBlock(relativeWidth, caption, head, body) = mt
+      val transformedCaption = caption map { c =>
+        val MultilineTableCaption(md) = c
+        processMarkdownContainer(md)(blocks => Right(Vector(MultilineTableCaption(blocks.toVector))))
+      }
+
+      val transformedHead = head map { head =>
+        processMarkdownContainer {
+          head.flatMap { h =>
+            val MultilineTableCell(bs) = h
+            bs
+          }
+        }(blocks => Right(Vector(MultilineTableCell(blocks.toVector))))
+      }
+
+      val transformedBodyColumns = body.
+        map { body =>
+          body.
+            map { h =>
+              val MultilineTableCell(blocks) = h
+              blocks
+            }.
+            map(processMarkdownContainer(_)(blocks => Right(Vector(MultilineTableCell(blocks.toVector))))) |>
+            join |>
+            (_.map(x => x.map(c => MultilineTableCell(c.toVector)).toVector))
+        } |>
+        join |>
+        (_.map(_.map(_.toVector).toVector))
+
+      (transformedCaption, transformedHead, transformedBodyColumns) match {
+        case (Some(Left(l)), _, _) => Left(l)
+        case (_, Some(Left(l)), _) => Left(l)
+        case (_, _, Left(l)) => Left(l)
+
+        case (c, h, b) =>
+          val cc = c.map(x => MultilineTableCaption(x.right.get.toVector))
+          val hh = h.map(y => Vector(MultilineTableCell(y.right.get.toVector)))
+          val bb = b.right.get
+          Right(Vector(MultilineTableBlock(relativeWidth, cc, hh, bb)))
+      }
+    }
+
     block match {
       case m @ Markdown(_) => processMarkdownBlock(m)
       case UnorderedList(v) => processMarkdownContainer(v)(blocks => Right(Vector(UnorderedList(blocks.toVector))))
       case OrderedList(v) => processMarkdownContainer(v)(blocks => Right(Vector(OrderedList(blocks.toVector))))
       case BlockQuote(v) => processMarkdownContainer(v)(blocks => Right(Vector(BlockQuote(blocks.toVector))))
-      case MultilineTableBlock(relativeWidth, caption, head, body) =>
-        val transformedCaption: Option[Either[Seq[FailureMessage], Seq[Block]]] = caption map { c =>
-          val MultilineTableCaption(md) = c
-          processMarkdownContainer(md)(blocks => Right(Vector(MultilineTableCaption(blocks.toVector))))
-        }
-
-        val transformedHead: Option[Either[Seq[FailureMessage], Seq[Block]]] = head map { head =>
-          val cells = head.flatMap { h =>
-            val MultilineTableCell(z) = h
-            z
-          } // ToDo Validate that flatten is correct here
-          processMarkdownContainer(cells)(blocks => Right(Vector(MultilineTableCell(blocks.toVector))))
-        }
-
-        val transformedBody: Vector[Either[Seq[FailureMessage], Vector[MultilineTableCell]]] = body map { body =>
-          body.map { h =>
-              val MultilineTableCell(blocks) = h
-              blocks
-            }
-            .map(processMarkdownContainer(_)(blocks => Right(Vector(MultilineTableCell(blocks.toVector))))) |>
-            join |>
-            (_.map(x => x.map(c => MultilineTableCell(c.toVector)).toVector))
-        }
-
-        // ToDo this is unsafe and should be re-implemented
-        val transformedBodyColumns: Either[Seq[FailureMessage], Vector[MultilineTableColumn]] =
-          transformedBody |> join |> (_.map(_.map(_.toVector).toVector))
-
-        (transformedCaption, transformedHead, transformedBodyColumns) match {
-          case (Some(Left(l)), _, _) =>  Left(l)
-          case (_, Some(Left(l)), _) => Left(l)
-          case (_, _,  Left(l)) =>  Left(l)
-
-          case (c,h,b) =>
-            val cc = c.map(x => MultilineTableCaption(x.right.get.toVector))
-            val hh= h.map(y => Vector(MultilineTableCell(y.right.get.toVector)))
-            val bb = b.right.get
-            Right(Vector(MultilineTableBlock(relativeWidth, cc, hh, bb)))
-        }
+      case mt @ MultilineTableBlock(_, _, _, _) => transformTable(mt)
       case _ => Right(Vector(block))
     }
   }
@@ -104,7 +107,7 @@ object ASTTransform {
     }
   }
 
-  def transformTree(tree: Seq[Block]): Either[Seq[FailureMessage], Seq[MacroBlock]] = {
+  def transformTree(tree: Seq[Block]): Either[Seq[FailureMessage], Seq[Seq[Block]]] = {
     tree.map(transformNode) |> join
   }
 }

--- a/src/main/scala/com/mdpeg/Block.scala
+++ b/src/main/scala/com/mdpeg/Block.scala
@@ -19,5 +19,5 @@ final case class MultilineTableBlock(relativeWidth: Vector[Float],
                                      body: Vector[MultilineTableColumn]) extends Block
 
 sealed trait MultilineTableElement
-final case class MultilineTableCaption(inline: Markdown) extends MultilineTableElement
+final case class MultilineTableCaption(inline: Vector[Block]) extends MultilineTableElement
 final case class MultilineTableCell(inline: Markdown) extends MultilineTableElement

--- a/src/main/scala/com/mdpeg/Block.scala
+++ b/src/main/scala/com/mdpeg/Block.scala
@@ -19,5 +19,5 @@ final case class MultilineTableBlock(relativeWidth: Vector[Float],
                                      body: Vector[MultilineTableColumn]) extends Block
 
 sealed trait MultilineTableElement
-final case class MultilineTableCaption(inline: Vector[Block]) extends MultilineTableElement
-final case class MultilineTableCell(inline: Vector[Block]) extends MultilineTableElement
+final case class MultilineTableCaption(inline: Vector[Block]) extends MultilineTableElement with Block
+final case class MultilineTableCell(inline: Vector[Block]) extends MultilineTableElement with Block

--- a/src/main/scala/com/mdpeg/Block.scala
+++ b/src/main/scala/com/mdpeg/Block.scala
@@ -19,5 +19,5 @@ final case class MultilineTableBlock(relativeWidth: Vector[Float],
                                      body: Vector[MultilineTableColumn]) extends Block
 
 sealed trait MultilineTableElement
-final case class MultilineTableCaption(inline: Vector[Block]) extends MultilineTableElement with Block
+final case class MultilineTableCaption(inline: Vector[Block], label: Option[String]) extends MultilineTableElement with Block
 final case class MultilineTableCell(inline: Vector[Block]) extends MultilineTableElement with Block

--- a/src/main/scala/com/mdpeg/Block.scala
+++ b/src/main/scala/com/mdpeg/Block.scala
@@ -20,4 +20,4 @@ final case class MultilineTableBlock(relativeWidth: Vector[Float],
 
 sealed trait MultilineTableElement
 final case class MultilineTableCaption(inline: Vector[Block]) extends MultilineTableElement
-final case class MultilineTableCell(inline: Markdown) extends MultilineTableElement
+final case class MultilineTableCell(inline: Vector[Block]) extends MultilineTableElement

--- a/src/main/scala/com/mdpeg/Inline.scala
+++ b/src/main/scala/com/mdpeg/Inline.scala
@@ -6,6 +6,6 @@ final case class Image(inline: InlineContent, target: Target, width: Option[Int]
 final case class Strong(inline: InlineContent) extends Inline
 final case class Italics(inline: InlineContent) extends Inline
 final case class Link(inline: InlineContent, target: Target) extends Inline
-final case class Text(inline: String) extends Inline //{ override def toString = s"""Text("${inline}")""" }
+final case class Text(inline: String) extends Inline { override def toString = s"""Text("${inline}")""" }
 final case object Space extends Inline
 final case object LineBreak extends Inline

--- a/src/main/scala/com/mdpeg/MultilineTablesRules.scala
+++ b/src/main/scala/com/mdpeg/MultilineTablesRules.scala
@@ -56,8 +56,8 @@ trait MultilineTablesRules {
 
     val relativeWidths = calculateRelativeWidths(width)
     val tableCaption = caption.map(inline => MultilineTableCaption(Vector(Markdown(inline))))
-    val headRow: Option[MultilineTableRow] = parsedHead.map(_.map(inline => MultilineTableCell(Markdown(inline))).toVector)
-    val bodyColumns: Vector[MultilineTableColumn] = body.map(_.map(inline => MultilineTableCell(Markdown(inline))).toVector)
+    val headRow: Option[MultilineTableRow] = parsedHead.map(_.map(inline => MultilineTableCell(Vector(Markdown(inline)))).toVector)
+    val bodyColumns: Vector[MultilineTableColumn] = body.map(_.map(inline => MultilineTableCell(Vector(Markdown(inline)))).toVector)
     MultilineTableBlock(relativeWidths, tableCaption, headRow, bodyColumns)
   }
 

--- a/src/main/scala/com/mdpeg/MultilineTablesRules.scala
+++ b/src/main/scala/com/mdpeg/MultilineTablesRules.scala
@@ -55,7 +55,7 @@ trait MultilineTablesRules {
     val parsedHead = head.map(parseHeadContent(width, _))
 
     val relativeWidths = calculateRelativeWidths(width)
-    val tableCaption = caption.map(inline => MultilineTableCaption(Markdown(inline)))
+    val tableCaption = caption.map(inline => MultilineTableCaption(Vector(Markdown(inline))))
     val headRow: Option[MultilineTableRow] = parsedHead.map(_.map(inline => MultilineTableCell(Markdown(inline))).toVector)
     val bodyColumns: Vector[MultilineTableColumn] = body.map(_.map(inline => MultilineTableCell(Markdown(inline))).toVector)
     MultilineTableBlock(relativeWidths, tableCaption, headRow, bodyColumns)

--- a/src/main/scala/com/mdpeg/Pipe.scala
+++ b/src/main/scala/com/mdpeg/Pipe.scala
@@ -1,0 +1,9 @@
+package com.mdpeg
+
+class Pipe[A](a: A) {
+  def |>[B](f: A => B) = f(a)
+}
+
+object Pipe {
+  def apply[A](v: A) = new Pipe(v)
+}

--- a/src/main/scala/com/mdpeg/package.scala
+++ b/src/main/scala/com/mdpeg/package.scala
@@ -56,4 +56,6 @@ package object mdpeg {
     }
     rest :: result
   }
+
+  implicit def toPipe[A](a: A): Pipe[A] = Pipe(a)
 }

--- a/src/test/scala/ASTTransformSpec.scala
+++ b/src/test/scala/ASTTransformSpec.scala
@@ -12,10 +12,22 @@ class ASTTransformSpec extends FlatSpec with Matchers {
          |""".stripMargin
     val parsed = new BlockParser(term).blockQuote.run().get
 
-    parsed.inline.map(transformNode).map(_.getOrElse(Vector.empty[Block])) shouldEqual
-    Vector(
-      Vector(Plain(Vector(Text("This"), Space, Text("is"), Space, Text("quote")))),
-      Vector(Plain(Vector(Text("and"), Space, Text("should"), Space, Text("span"), Space, Text("several")))),
-      Vector(Plain(Vector(Text("yet"), Space, Text("another"), Space, Text("line"), Space, Text("for"), Space, Text("the"), Space, Text("block")))))
+//    parsed.inline.map(transformNode).map(_.getOrElse(Vector.empty[Block])) shouldEqual
+//    Vector(
+//      Vector(
+//        Plain(Vector(Text("This"), Space, Text("is"), Space, Text("quote")))),
+//      Vector(
+//        Plain(Vector(Text("and"), Space, Text("should"), Space, Text("span"), Space, Text("several")))),
+//      Vector(
+//        Plain(Vector(Text("yet"), Space, Text("another"), Space, Text("line"), Space, Text("for"), Space, Text("the"), Space, Text("block"))))
+//    )
+
+    parsed.inline |> transformTree  shouldEqual
+    Right(
+      Vector(
+        Vector(Plain(Vector(Text("This"), Space, Text("is"), Space, Text("quote")))),
+        Vector(Plain(Vector(Text("and"), Space, Text("should"), Space, Text("span"), Space, Text("several")))),
+        Vector(Plain(Vector(Text("yet"), Space, Text("another"), Space, Text("line"), Space, Text("for"), Space, Text("the"), Space, Text("block")))))
+    )
   }
 }

--- a/src/test/scala/ASTTransformSpec.scala
+++ b/src/test/scala/ASTTransformSpec.scala
@@ -32,15 +32,25 @@ class ASTTransformSpec extends FlatSpec with Matchers {
     )
     val transformedTree = rawAstTree |> transformTree
 
+//    transformedTree shouldEqual
+//      Right(
+//        Vector(
+//          Vector(
+//            Plain(Vector(Text("This"), Space, Text("is"), Space, Text("quote"))),
+//            Plain(Vector(Text("and"), Space, Text("should"), Space, Text("span"), Space, Text("several"))),
+//            Plain(Vector(Text("yet"), Space, Text("another"), Space, Text("line"), Space, Text("for"), Space, Text("the"), Space, Text("block"))))
+//        )
+//      )
     transformedTree shouldEqual
-      Right(
+    Right(
+      Vector(
         Vector(
-          Vector(
-            Plain(Vector(Text("This"), Space, Text("is"), Space, Text("quote"))),
-            Plain(Vector(Text("and"), Space, Text("should"), Space, Text("span"), Space, Text("several"))),
-            Plain(Vector(Text("yet"), Space, Text("another"), Space, Text("line"), Space, Text("for"), Space, Text("the"), Space, Text("block"))))
-        )
-      )
+          BlockQuote(
+            Vector(
+              Plain(Vector(Text("This"), Space, Text("is"), Space, Text("quote"))),
+              Plain(Vector(Text("and"), Space, Text("should"), Space, Text("span"), Space, Text("several"))),
+              Plain(Vector(Text("yet"), Space, Text("another"), Space, Text("line"), Space, Text("for"), Space, Text("the"), Space, Text("block")))))))
+    )
   }
 
   it should "process multiple nested levels of Markdown blocks nested inside other blocks" in {
@@ -60,17 +70,18 @@ class ASTTransformSpec extends FlatSpec with Matchers {
     val transformedTree = rawAstTree |> transformTree
 
     transformedTree shouldEqual
-      Right(
+    Right(
+      Vector(
         Vector(
-          Vector(
-            Plain(Vector(Text("This"), Space, Text("is"), Space, Text("quote"))),
-            BlockQuote(
-              Vector(
-                Plain(Vector(Text("This"), Space, Text("is"), Space, Text("quote"))),
-                Plain(Vector(Text("and"), Space, Text("should"), Space, Text("span"), Space, Text("several"))),
-                Plain(Vector(Text("yet"), Space, Text("another"), Space, Text("line"), Space, Text("for"), Space, Text("the"), Space, Text("block"))))
-            ),
-            Plain(Vector(Text("yet"), Space, Text("another"), Space, Text("line"), Space, Text("for"), Space, Text("the"), Space, Text("block")))))
-      )
+          BlockQuote(
+            Vector(
+              Plain(Vector(Text("This"), Space, Text("is"), Space, Text("quote"))),
+              BlockQuote(
+                Vector(
+                  Plain(Vector(Text("This"), Space, Text("is"), Space, Text("quote"))),
+                  Plain(Vector(Text("and"), Space, Text("should"), Space, Text("span"), Space, Text("several"))),
+                  Plain(Vector(Text("yet"), Space, Text("another"), Space, Text("line"), Space, Text("for"), Space, Text("the"), Space, Text("block"))))),
+              Plain(Vector(Text("yet"), Space, Text("another"), Space, Text("line"), Space, Text("for"), Space, Text("the"), Space, Text("block")))))))
+    )
   }
 }

--- a/src/test/scala/ASTTransformSpec.scala
+++ b/src/test/scala/ASTTransformSpec.scala
@@ -42,4 +42,35 @@ class ASTTransformSpec extends FlatSpec with Matchers {
         )
       )
   }
+
+  it should "process multiple nested levels of Markdown blocks nested inside other blocks" in {
+    val term =
+      s"""> ${TestData.blockQuoteLineOne}
+         |> ${TestData.blockQuoteLineTwo}
+         |> ${TestData.blockQuoteLineThree}
+         |""".stripMargin
+
+    val rawAstTree = Vector(
+      BlockQuote(
+        Vector(
+          Markdown("This is quote"),
+          Markdown(term),
+          Markdown("yet another line for the block")))
+    )
+    val transformedTree = rawAstTree |> transformTree
+
+    transformedTree shouldEqual
+      Right(
+        Vector(
+          Vector(
+            Plain(Vector(Text("This"), Space, Text("is"), Space, Text("quote"))),
+            BlockQuote(
+              Vector(
+                Plain(Vector(Text("This"), Space, Text("is"), Space, Text("quote"))),
+                Plain(Vector(Text("and"), Space, Text("should"), Space, Text("span"), Space, Text("several"))),
+                Plain(Vector(Text("yet"), Space, Text("another"), Space, Text("line"), Space, Text("for"), Space, Text("the"), Space, Text("block"))))
+            ),
+            Plain(Vector(Text("yet"), Space, Text("another"), Space, Text("line"), Space, Text("for"), Space, Text("the"), Space, Text("block")))))
+      )
+  }
 }

--- a/src/test/scala/ASTTransformSpec.scala
+++ b/src/test/scala/ASTTransformSpec.scala
@@ -96,4 +96,43 @@ class ASTTransformSpec extends FlatSpec with Matchers {
           Vector(MultilineTableCell(Vector(MultilineTableCell(Vector(Plain(Vector(Space, Text(":)"))))))))
         )))))
   }
+
+  it should "parse Multiline Table's nested elements" in {
+    val rawTree = Vector(MultilineTableBlock(
+      Vector(20.0f, 20.0f, 20.0f, 20.0f, 20.0f),
+      //Some(MultilineTableCaption(Vector(Markdown("This is a table caption\\label{table:table_lable_name}")))),
+      None,
+      Some(
+        Vector(
+          MultilineTableCell(Vector(Markdown("Term  1"))),
+          MultilineTableCell(Vector(Markdown("Term  2"))),
+          MultilineTableCell(Vector(Markdown("Term  3"))),
+          MultilineTableCell(Vector(Markdown("Term  4"))),
+          MultilineTableCell(Vector(Markdown("Term  5"))))),
+      Vector(
+        Vector(MultilineTableCell(Vector(Markdown(".It")))),
+        Vector(MultilineTableCell(Vector(Markdown("is")))),
+        Vector(MultilineTableCell(Vector(Markdown(" a")))),
+        Vector(MultilineTableCell(Vector(Markdown("rectangular")))),
+        Vector(MultilineTableCell(Vector(Markdown("table")))))))
+
+    val transformedTree = rawTree |> transformTree
+
+    transformedTree shouldEqual
+      Right(Vector(Vector(MultilineTableBlock(Vector(20.0f, 20.0f, 20.0f, 20.0f, 20.0f),None,
+        Some(Vector(
+              MultilineTableCell(Vector(Plain(Vector(Text("Term"), Space, Text("1"))))),
+              MultilineTableCell(Vector(Plain(Vector(Text("Term"), Space, Text("2"))))),
+              MultilineTableCell(Vector(Plain(Vector(Text("Term"), Space, Text("3"))))),
+              MultilineTableCell(Vector(Plain(Vector(Text("Term"), Space, Text("4"))))),
+              MultilineTableCell(Vector(Plain(Vector(Text("Term"), Space, Text("5")))))
+            )),
+        Vector(
+          Vector(MultilineTableCell(Vector(Plain(Vector(Text(".It")))))),
+          Vector(MultilineTableCell(Vector(Plain(Vector(Text("is")))))),
+          Vector(MultilineTableCell(Vector(Plain(Vector(Space, Text("a")))))),
+          Vector(MultilineTableCell(Vector(Plain(Vector(Text("rectangular")))))),
+          Vector(MultilineTableCell(Vector(Plain(Vector(Text("table"      ))))))
+      )))))
+  }
 }

--- a/src/test/scala/ASTTransformSpec.scala
+++ b/src/test/scala/ASTTransformSpec.scala
@@ -21,4 +21,25 @@ class ASTTransformSpec extends FlatSpec with Matchers {
         Vector(Plain(Vector(Text("yet"), Space, Text("another"), Space, Text("line"), Space, Text("for"), Space, Text("the"), Space, Text("block")))))
     )
   }
+
+  it should "process Markdown blocks nested inside other blocks" in {
+    val rawAstTree = Vector(
+      BlockQuote(
+        Vector(
+          Markdown("This is quote"),
+          Markdown("and should span several"),
+          Markdown("yet another line for the block")))
+    )
+    val transformedTree = rawAstTree |> transformTree
+
+    transformedTree shouldEqual
+      Right(
+        Vector(
+          Vector(
+            Plain(Vector(Text("This"), Space, Text("is"), Space, Text("quote"))),
+            Plain(Vector(Text("and"), Space, Text("should"), Space, Text("span"), Space, Text("several"))),
+            Plain(Vector(Text("yet"), Space, Text("another"), Space, Text("line"), Space, Text("for"), Space, Text("the"), Space, Text("block"))))
+        )
+      )
+  }
 }

--- a/src/test/scala/ASTTransformSpec.scala
+++ b/src/test/scala/ASTTransformSpec.scala
@@ -97,11 +97,10 @@ class ASTTransformSpec extends FlatSpec with Matchers {
         )))))
   }
 
-  it should "parse Multiline Table's nested elements" in {
+  it should "parse nested elements in a rectangular Multiline Table" in {
     val rawTree = Vector(MultilineTableBlock(
       Vector(20.0f, 20.0f, 20.0f, 20.0f, 20.0f),
-      //Some(MultilineTableCaption(Vector(Markdown("This is a table caption\\label{table:table_lable_name}")))),
-      None,
+      Some(MultilineTableCaption(Vector(Markdown("This is a table caption")), Some("table:table_lable_name"))),
       Some(
         Vector(
           MultilineTableCell(Vector(Markdown("Term  1"))),
@@ -119,7 +118,10 @@ class ASTTransformSpec extends FlatSpec with Matchers {
     val transformedTree = rawTree |> transformTree
 
     transformedTree shouldEqual
-      Right(Vector(Vector(MultilineTableBlock(Vector(20.0f, 20.0f, 20.0f, 20.0f, 20.0f),None,
+      Right(Vector(Vector(MultilineTableBlock(Vector(20.0f, 20.0f, 20.0f, 20.0f, 20.0f),
+        Some(
+          MultilineTableCaption(Vector(Plain(Vector(Text("This"), Space, Text("is"), Space, Text("a"), Space, Text("table"), Space, Text("caption")))),
+          Some("table:table_lable_name"))),
         Some(Vector(
               MultilineTableCell(Vector(Plain(Vector(Text("Term"), Space, Text("1"))))),
               MultilineTableCell(Vector(Plain(Vector(Text("Term"), Space, Text("2"))))),
@@ -136,4 +138,44 @@ class ASTTransformSpec extends FlatSpec with Matchers {
       )))))
   }
 
+  it should "parse Multiline Table's with nested elements spanning multiple lines in a cell" in {
+    val rawTree = Vector(
+      MultilineTableBlock(Vector(25.0f, 75.0f),
+      Some(MultilineTableCaption(Vector(Markdown("This is a table caption")),Some("table:table_lable_name"))),
+        Some(Vector(MultilineTableCell(Vector(Markdown(
+          """Term  1
+            |Term  cont""".stripMargin))),
+          MultilineTableCell(Vector(Markdown(
+            """Description 1
+              |Description cont""".stripMargin))))),
+        Vector(
+          Vector(
+            MultilineTableCell(Vector(Markdown(".It"))),
+            MultilineTableCell(Vector(Markdown(
+              """CAPSED WORD
+                |Many""".stripMargin)))),
+          Vector(
+            MultilineTableCell(Vector(Markdown("is a long established fact that"))),
+            MultilineTableCell(Vector(Markdown(
+              """The point of using Lorem Ipsum is
+                |desktop publishing packages and""".stripMargin))))
+        )))
+
+    val transformedTree = rawTree |> transformTree
+
+    transformedTree shouldEqual
+      Right(Vector(Vector(MultilineTableBlock(Vector(25.0f, 75.0f),
+        Some(MultilineTableCaption(Vector(Plain(Vector(Text("This"), Space, Text("is"), Space, Text("a"), Space, Text("table"), Space, Text("caption")))),Some("table:table_lable_name"))),
+        Some(Vector(
+          MultilineTableCell(Vector(Plain(Vector(Text("Term"), Space, Text("1"), Space, Text("Term"), Space, Text("cont"))))),
+          MultilineTableCell(Vector(Plain(Vector(Text("Description"), Space, Text("1"), Space, Text("Description"), Space, Text("cont"))))))),
+        Vector(
+          Vector(
+            MultilineTableCell(Vector(Plain(Vector(Text(".It"))))),
+            MultilineTableCell(Vector(Plain(Vector(Text("CAPSED"), Space, Text("WORD"), Space, Text("Many")))))),
+          Vector(
+            MultilineTableCell(Vector(Plain(Vector(Text("is"), Space, Text("a"), Space, Text("long"), Space, Text("established"), Space, Text("fact"), Space, Text("that"))))),
+            MultilineTableCell(Vector(Plain(Vector(Text("The"), Space, Text("point"), Space, Text("of"), Space, Text("using"), Space, Text("Lorem"), Space, Text("Ipsum"), Space, Text("is"), Space, Text("desktop"), Space, Text("publishing"), Space, Text("packages"), Space, Text("and"))))))
+        )))))
+  }
 }

--- a/src/test/scala/ASTTransformSpec.scala
+++ b/src/test/scala/ASTTransformSpec.scala
@@ -32,15 +32,6 @@ class ASTTransformSpec extends FlatSpec with Matchers {
     )
     val transformedTree = rawAstTree |> transformTree
 
-//    transformedTree shouldEqual
-//      Right(
-//        Vector(
-//          Vector(
-//            Plain(Vector(Text("This"), Space, Text("is"), Space, Text("quote"))),
-//            Plain(Vector(Text("and"), Space, Text("should"), Space, Text("span"), Space, Text("several"))),
-//            Plain(Vector(Text("yet"), Space, Text("another"), Space, Text("line"), Space, Text("for"), Space, Text("the"), Space, Text("block"))))
-//        )
-//      )
     transformedTree shouldEqual
     Right(
       Vector(
@@ -83,5 +74,24 @@ class ASTTransformSpec extends FlatSpec with Matchers {
                   Plain(Vector(Text("yet"), Space, Text("another"), Space, Text("line"), Space, Text("for"), Space, Text("the"), Space, Text("block"))))),
               Plain(Vector(Text("yet"), Space, Text("another"), Space, Text("line"), Space, Text("for"), Space, Text("the"), Space, Text("block")))))))
     )
+  }
+
+  it should "parse Multiline Table's nested elements" in {
+    val term =
+      """-----------   -----------   -----------   -----------  -----------
+        |.It is longer than neccesary and it should be truncated :)
+        |--------------------------------------------------------------------------------
+        |""".stripMargin
+    val transformedTree = new BlockParser(term).InputLine.run().get |> transformTree
+
+    transformedTree shouldEqual
+      Right(Vector(Vector(MultilineTableBlock(Vector(20.0f, 20.0f, 20.0f, 20.0f, 20.0f),None,None,
+        Vector(
+          Vector(MultilineTableCell(Vector(MultilineTableCell(Vector(Plain(Vector(Text(".It"), Space, Text("is"), Space, Text("longer")))))))),
+          Vector(MultilineTableCell(Vector(MultilineTableCell(Vector(Plain(Vector(Text("than"), Space, Text("neccesary")))))))),
+          Vector(MultilineTableCell(Vector(MultilineTableCell(Vector(Plain(Vector(Space, Text("and"), Space, Text("it"), Space, Text("should")))))))),
+          Vector(MultilineTableCell(Vector(MultilineTableCell(Vector(Plain(Vector(Space, Text("be"), Space, Text("truncated")))))))),
+          Vector(MultilineTableCell(Vector(MultilineTableCell(Vector(Plain(Vector(Space, Text(":)"))))))))
+        )))))
   }
 }

--- a/src/test/scala/ASTTransformSpec.scala
+++ b/src/test/scala/ASTTransformSpec.scala
@@ -1,0 +1,21 @@
+import com.mdpeg.ASTTransform._
+import com.mdpeg._
+import org.scalatest.{FlatSpec, Matchers}
+
+class ASTTransformSpec extends FlatSpec with Matchers {
+
+  it should "Should extract one level of Markdown to block seq" in {
+    val term =
+      s"""> ${TestData.blockQuoteLineOne}
+         |> ${TestData.blockQuoteLineTwo}
+         |> ${TestData.blockQuoteLineThree}
+         |""".stripMargin
+    val parsed = new BlockParser(term).blockQuote.run().get
+
+    parsed.inline.map(transformNode).map(_.getOrElse(Vector.empty[Block])) shouldEqual
+    Vector(
+      Vector(Plain(Vector(Text("This"), Space, Text("is"), Space, Text("quote")))),
+      Vector(Plain(Vector(Text("and"), Space, Text("should"), Space, Text("span"), Space, Text("several")))),
+      Vector(Plain(Vector(Text("yet"), Space, Text("another"), Space, Text("line"), Space, Text("for"), Space, Text("the"), Space, Text("block")))))
+  }
+}

--- a/src/test/scala/ASTTransformSpec.scala
+++ b/src/test/scala/ASTTransformSpec.scala
@@ -89,11 +89,11 @@ class ASTTransformSpec extends FlatSpec with Matchers {
     transformedTree shouldEqual
       Right(Vector(Vector(MultilineTableBlock(Vector(20.0f, 20.0f, 20.0f, 20.0f, 20.0f),None,None,
         Vector(
-          Vector(MultilineTableCell(Vector(MultilineTableCell(Vector(Plain(Vector(Text(".It"), Space, Text("is"), Space, Text("longer")))))))),
-          Vector(MultilineTableCell(Vector(MultilineTableCell(Vector(Plain(Vector(Text("than"), Space, Text("neccesary")))))))),
-          Vector(MultilineTableCell(Vector(MultilineTableCell(Vector(Plain(Vector(Space, Text("and"), Space, Text("it"), Space, Text("should")))))))),
-          Vector(MultilineTableCell(Vector(MultilineTableCell(Vector(Plain(Vector(Space, Text("be"), Space, Text("truncated")))))))),
-          Vector(MultilineTableCell(Vector(MultilineTableCell(Vector(Plain(Vector(Space, Text(":)"))))))))
+          Vector(MultilineTableCell(Vector(Plain(Vector(Text(".It"), Space, Text("is"), Space, Text("longer")))))),
+          Vector(MultilineTableCell(Vector(Plain(Vector(Text("than"), Space, Text("neccesary")))))),
+          Vector(MultilineTableCell(Vector(Plain(Vector(Space, Text("and"), Space, Text("it"), Space, Text("should")))))),
+          Vector(MultilineTableCell(Vector(Plain(Vector(Space, Text("be"), Space, Text("truncated")))))),
+          Vector(MultilineTableCell(Vector(Plain(Vector(Space, Text(":)"))))))
         )))))
   }
 
@@ -135,4 +135,5 @@ class ASTTransformSpec extends FlatSpec with Matchers {
           Vector(MultilineTableCell(Vector(Plain(Vector(Text("table"      ))))))
       )))))
   }
+
 }

--- a/src/test/scala/ASTTransformSpec.scala
+++ b/src/test/scala/ASTTransformSpec.scala
@@ -4,25 +4,16 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class ASTTransformSpec extends FlatSpec with Matchers {
 
-  it should "Should extract one level of Markdown to block seq" in {
-    val term =
-      s"""> ${TestData.blockQuoteLineOne}
-         |> ${TestData.blockQuoteLineTwo}
-         |> ${TestData.blockQuoteLineThree}
-         |""".stripMargin
-    val parsed = new BlockParser(term).blockQuote.run().get
+  it should "transform one level of Markdown to block seq" in {
+    val rawAstTree = Vector(
+      Markdown("This is quote"),
+      Markdown("and should span several"),
+      Markdown("yet another line for the block")
+    )
 
-//    parsed.inline.map(transformNode).map(_.getOrElse(Vector.empty[Block])) shouldEqual
-//    Vector(
-//      Vector(
-//        Plain(Vector(Text("This"), Space, Text("is"), Space, Text("quote")))),
-//      Vector(
-//        Plain(Vector(Text("and"), Space, Text("should"), Space, Text("span"), Space, Text("several")))),
-//      Vector(
-//        Plain(Vector(Text("yet"), Space, Text("another"), Space, Text("line"), Space, Text("for"), Space, Text("the"), Space, Text("block"))))
-//    )
+    val transformedTree = rawAstTree |> transformTree
 
-    parsed.inline |> transformTree  shouldEqual
+    transformedTree shouldEqual
     Right(
       Vector(
         Vector(Plain(Vector(Text("This"), Space, Text("is"), Space, Text("quote")))),

--- a/src/test/scala/ASTTransformSpec.scala
+++ b/src/test/scala/ASTTransformSpec.scala
@@ -76,13 +76,15 @@ class ASTTransformSpec extends FlatSpec with Matchers {
     )
   }
 
-  it should "parse Multiline Table's nested elements" in {
-    val term =
-      """-----------   -----------   -----------   -----------  -----------
-        |.It is longer than neccesary and it should be truncated :)
-        |--------------------------------------------------------------------------------
-        |""".stripMargin
-    val transformedTree = new BlockParser(term).InputLine.run().get |> transformTree
+  it should "parse Multiline Table's body nested elements" in {
+    val rawTree = Vector(MultilineTableBlock(Vector(20.0f, 20.0f, 20.0f, 20.0f, 20.0f),None,None,
+      Vector(
+        Vector(MultilineTableCell(Vector(Markdown(".It is longer")))),
+        Vector(MultilineTableCell(Vector(Markdown("than neccesary")))),
+        Vector(MultilineTableCell(Vector(Markdown(" and it should")))),
+        Vector(MultilineTableCell(Vector(Markdown(" be truncated")))),
+        Vector(MultilineTableCell(Vector(Markdown(" :)")))))))
+    val transformedTree = rawTree |> transformTree
 
     transformedTree shouldEqual
       Right(Vector(Vector(MultilineTableBlock(Vector(20.0f, 20.0f, 20.0f, 20.0f, 20.0f),None,None,

--- a/src/test/scala/ASTTransformSpec.scala
+++ b/src/test/scala/ASTTransformSpec.scala
@@ -4,7 +4,7 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class ASTTransformSpec extends FlatSpec with Matchers {
 
-  it should "transform one level of Markdown to block seq" in {
+  it should "parse Markdown blocks to block seq" in {
     val rawAstTree = Vector(
       Markdown("This is quote"),
       Markdown("and should span several"),

--- a/src/test/scala/ExpectedTestResults.scala
+++ b/src/test/scala/ExpectedTestResults.scala
@@ -38,7 +38,7 @@ object ExpectedTestResults {
       |""".stripMargin), Markdown(
     """And, finally, this is a second item of an ordered list
       |""".stripMargin)))
-  val complexTable = MultilineTableBlock(Vector(25.0f, 75.0f), Some(MultilineTableCaption(Vector(Markdown("This is a table caption\\label{table:table_lable_name}")))), Some(Vector(MultilineTableCell(Vector(Markdown("This header is longer than sep"))), MultilineTableCell(Vector(Markdown("And this header is also longer than this separator"))))), Vector(Vector(MultilineTableCell(Vector(Markdown("**Why do we use it?**"))), MultilineTableCell(Vector(Markdown(
+  val complexTable = MultilineTableBlock(Vector(25.0f, 75.0f), Some(MultilineTableCaption(Vector(Markdown("This is a table caption")), Some("table:table_lable_name"))), Some(Vector(MultilineTableCell(Vector(Markdown("This header is longer than sep"))), MultilineTableCell(Vector(Markdown("And this header is also longer than this separator"))))), Vector(Vector(MultilineTableCell(Vector(Markdown("**Why do we use it?**"))), MultilineTableCell(Vector(Markdown(
     """There-are
       |""".stripMargin))), MultilineTableCell(Vector(Markdown("**Where can I get some?**"))), MultilineTableCell(Vector(Markdown(
     """dummy

--- a/src/test/scala/ExpectedTestResults.scala
+++ b/src/test/scala/ExpectedTestResults.scala
@@ -38,7 +38,7 @@ object ExpectedTestResults {
       |""".stripMargin), Markdown(
     """And, finally, this is a second item of an ordered list
       |""".stripMargin)))
-  val complexTable = MultilineTableBlock(Vector(25.0f, 75.0f), Some(MultilineTableCaption(Markdown("This is a table caption\\label{table:table_lable_name}"))), Some(Vector(MultilineTableCell(Markdown("This header is longer than sep")), MultilineTableCell(Markdown("And this header is also longer than this separator")))), Vector(Vector(MultilineTableCell(Markdown("**Why do we use it?**")), MultilineTableCell(Markdown(
+  val complexTable = MultilineTableBlock(Vector(25.0f, 75.0f), Some(MultilineTableCaption(Vector(Markdown("This is a table caption\\label{table:table_lable_name}")))), Some(Vector(MultilineTableCell(Markdown("This header is longer than sep")), MultilineTableCell(Markdown("And this header is also longer than this separator")))), Vector(Vector(MultilineTableCell(Markdown("**Why do we use it?**")), MultilineTableCell(Markdown(
     """There-are
       |""".stripMargin)), MultilineTableCell(Markdown("**Where can I get some?**")), MultilineTableCell(Markdown(
     """dummy

--- a/src/test/scala/ExpectedTestResults.scala
+++ b/src/test/scala/ExpectedTestResults.scala
@@ -38,33 +38,33 @@ object ExpectedTestResults {
       |""".stripMargin), Markdown(
     """And, finally, this is a second item of an ordered list
       |""".stripMargin)))
-  val complexTable = MultilineTableBlock(Vector(25.0f, 75.0f), Some(MultilineTableCaption(Vector(Markdown("This is a table caption\\label{table:table_lable_name}")))), Some(Vector(MultilineTableCell(Markdown("This header is longer than sep")), MultilineTableCell(Markdown("And this header is also longer than this separator")))), Vector(Vector(MultilineTableCell(Markdown("**Why do we use it?**")), MultilineTableCell(Markdown(
+  val complexTable = MultilineTableBlock(Vector(25.0f, 75.0f), Some(MultilineTableCaption(Vector(Markdown("This is a table caption\\label{table:table_lable_name}")))), Some(Vector(MultilineTableCell(Vector(Markdown("This header is longer than sep"))), MultilineTableCell(Vector(Markdown("And this header is also longer than this separator"))))), Vector(Vector(MultilineTableCell(Vector(Markdown("**Why do we use it?**"))), MultilineTableCell(Vector(Markdown(
     """There-are
-      |""".stripMargin)), MultilineTableCell(Markdown("**Where can I get some?**")), MultilineTableCell(Markdown(
+      |""".stripMargin))), MultilineTableCell(Vector(Markdown("**Where can I get some?**"))), MultilineTableCell(Vector(Markdown(
     """dummy
-      |""".stripMargin)), MultilineTableCell(Markdown("text")), MultilineTableCell(Markdown("printing")), MultilineTableCell(Markdown("**Where does it come from?**")), MultilineTableCell(Markdown(
+      |""".stripMargin))), MultilineTableCell(Vector(Markdown("text"))), MultilineTableCell(Vector(Markdown("printing"))), MultilineTableCell(Vector(Markdown("**Where does it come from?**"))), MultilineTableCell(Vector(Markdown(
     """leap-into
-      |""".stripMargin)), MultilineTableCell(Markdown(
+      |""".stripMargin))), MultilineTableCell(Vector(Markdown(
     """variations-join
       |
-      |""".stripMargin)), MultilineTableCell(Markdown("**What is Lorem Ipsum?**")), MultilineTableCell(Markdown(
+      |""".stripMargin))), MultilineTableCell(Vector(Markdown("**What is Lorem Ipsum?**"))), MultilineTableCell(Vector(Markdown(
     """Lorem
-      |""".stripMargin)), MultilineTableCell(Markdown(
+      |""".stripMargin))), MultilineTableCell(Vector(Markdown(
     """anything
-      |""".stripMargin))), Vector(MultilineTableCell(Markdown(
+      |""".stripMargin)))), Vector(MultilineTableCell(Vector(Markdown(
     """It is a long established fact that a reader will be
-      |distracted by the readable content of a page when looking at""".stripMargin)), MultilineTableCell(Markdown(
+      |distracted by the readable content of a page when looking at""".stripMargin))), MultilineTableCell(Vector(Markdown(
     """It uses a dictionary of over
-      |Lorem Ipsum which looks reasonable""".stripMargin)), MultilineTableCell(Markdown("The generated Lorem Ipsum is")), MultilineTableCell(Markdown("or non-characteristic words etc")), MultilineTableCell(Markdown(
+      |Lorem Ipsum which looks reasonable""".stripMargin))), MultilineTableCell(Vector(Markdown("The generated Lorem Ipsum is"))), MultilineTableCell(Vector(Markdown("or non-characteristic words etc"))), MultilineTableCell(Vector(Markdown(
     """It uses a dictionary of over 200
-      |you need to be sure there""".stripMargin)), MultilineTableCell(Markdown(
+      |you need to be sure there""".stripMargin))), MultilineTableCell(Vector(Markdown(
     """anything embarrassing hidden
       |you need to be sure there isn't
-      |within this period""".stripMargin)), MultilineTableCell(Markdown(
+      |within this period""".stripMargin))), MultilineTableCell(Vector(Markdown(
     """"There are many variations of passages.
-      |*randomised words which : 1597 z*""".stripMargin)), MultilineTableCell(Markdown(
+      |*randomised words which : 1597 z*""".stripMargin))), MultilineTableCell(Vector(Markdown(
     """but the majority have suffered alteration.
-      |*to use a passage: "" (empty string)*""".stripMargin)))))
+      |*to use a passage: "" (empty string)*""".stripMargin))))))
 
   val referenceType1 = ReferenceBlock(Vector(Text("arbitrary"), Space, Text("case-insensitive"), Space, Text("reference"), Space, Text("text")), Src("https://www.mozilla.org", Some("this is title")))
   val referenceType2 = ReferenceBlock(Vector(Text("arbitrary"), Space, Text("case-insensitive"), Space, Text("123")), Src("https://www.mozilla.org", None))

--- a/src/test/scala/MultilineTablesRulesSpec.scala
+++ b/src/test/scala/MultilineTablesRulesSpec.scala
@@ -9,12 +9,12 @@ class MultilineTablesRulesSpec extends FlatSpec with Matchers {
 
   def tableMock(bodyColumns: Vector[MultilineTableColumn],
                 head: Option[MultilineTableRow] = Some(Vector(
-                  MultilineTableCell(Markdown(
+                  MultilineTableCell(Vector(Markdown(
                     """Term  1
-                      |Term  cont""".stripMargin)),
-                  MultilineTableCell(Markdown(
+                      |Term  cont""".stripMargin))),
+                  MultilineTableCell(Vector(Markdown(
                     """Description 1
-                      |Description cont""".stripMargin)))),
+                      |Description cont""".stripMargin))))),
                 widths: Vector[Float] = Vector(25.0f, 75.0f)) = MultilineTableBlock(
     widths,
     Some(MultilineTableCaption(Vector(Markdown("This is a table caption\\label{table:table_lable_name}")))),
@@ -120,13 +120,13 @@ class MultilineTablesRulesSpec extends FlatSpec with Matchers {
     val parser = new MultilineTablesRulesTestSpec(term)
     parser.multiTable.run().get shouldEqual tableMock(Vector(
       Vector(
-        MultilineTableCell(Markdown(".It")),
-        MultilineTableCell(Markdown("CAPSED WORD")),
-        MultilineTableCell(Markdown("Many"))),
+        MultilineTableCell(Vector(Markdown(".It"))),
+        MultilineTableCell(Vector(Markdown("CAPSED WORD"))),
+        MultilineTableCell(Vector(Markdown("Many")))),
       Vector(
-        MultilineTableCell(Markdown("is a long established fact that")),
-        MultilineTableCell(Markdown("The point of using Lorem Ipsum is")),
-        MultilineTableCell(Markdown("desktop publishing packages and"))))
+        MultilineTableCell(Vector(Markdown("is a long established fact that"))),
+        MultilineTableCell(Vector(Markdown("The point of using Lorem Ipsum is"))),
+        MultilineTableCell(Vector(Markdown("desktop publishing packages and")))))
       )
   }
 
@@ -146,13 +146,13 @@ class MultilineTablesRulesSpec extends FlatSpec with Matchers {
     val parser = new MultilineTablesRulesTestSpec(term)
     parser.multiTable.run().get shouldEqual tableMock(Vector(
       Vector(
-        MultilineTableCell(Markdown(".It")),
-        MultilineTableCell(Markdown("""CAPSED WORD
-            |Many""".stripMargin))),
+        MultilineTableCell(Vector(Markdown(".It"))),
+        MultilineTableCell(Vector(Markdown("""CAPSED WORD
+            |Many""".stripMargin)))),
       Vector(
-        MultilineTableCell(Markdown("is a long established fact that")),
-        MultilineTableCell(Markdown("""The point of using Lorem Ipsum is
-                                      |desktop publishing packages and""".stripMargin)))))
+        MultilineTableCell(Vector(Markdown("is a long established fact that"))),
+        MultilineTableCell(Vector(Markdown("""The point of using Lorem Ipsum is
+                                      |desktop publishing packages and""".stripMargin))))))
   }
 
   it should "eliminate trailing empty line in body row" in {
@@ -170,8 +170,8 @@ class MultilineTablesRulesSpec extends FlatSpec with Matchers {
         |Table: This is a table caption\label{table:table_lable_name}""".stripMargin
     val parser = new MultilineTablesRulesTestSpec(term)
     parser.multiTable.run().get shouldEqual tableMock(Vector(
-      Vector(MultilineTableCell(Markdown(".It"))),
-      Vector(MultilineTableCell(Markdown("is a long established fact that"))
+      Vector(MultilineTableCell(Vector(Markdown(".It")))),
+      Vector(MultilineTableCell(Vector(Markdown("is a long established fact that")))
     )))
   }
 
@@ -188,9 +188,9 @@ class MultilineTablesRulesSpec extends FlatSpec with Matchers {
         |Table: This is a table caption\label{table:table_lable_name}""".stripMargin
     val parser = new MultilineTablesRulesTestSpec(term)
     parser.multiTable.run().get shouldEqual tableMock(
-      Vector(Vector(MultilineTableCell(Markdown(".It")))),
-      Some(Vector(MultilineTableCell(Markdown("""Term  1
-                                                |Term  cont""".stripMargin)))),
+      Vector(Vector(MultilineTableCell(Vector(Markdown(".It"))))),
+      Some(Vector(MultilineTableCell(Vector(Markdown("""Term  1
+                                                |Term  cont""".stripMargin))))),
       Vector(100.0f))
   }
 
@@ -208,17 +208,17 @@ class MultilineTablesRulesSpec extends FlatSpec with Matchers {
       Some(MultilineTableCaption(Vector(Markdown("This is a table caption\\label{table:table_lable_name}")))),
       Some(
         Vector(
-          MultilineTableCell(Markdown("Term  1")),
-          MultilineTableCell(Markdown("Term  2")),
-          MultilineTableCell(Markdown("Term  3")),
-          MultilineTableCell(Markdown("Term  4")),
-          MultilineTableCell(Markdown("Term  5")))),
+          MultilineTableCell(Vector(Markdown("Term  1"))),
+          MultilineTableCell(Vector(Markdown("Term  2"))),
+          MultilineTableCell(Vector(Markdown("Term  3"))),
+          MultilineTableCell(Vector(Markdown("Term  4"))),
+          MultilineTableCell(Vector(Markdown("Term  5"))))),
       Vector(
-        Vector(MultilineTableCell(Markdown(".It"))),
-        Vector(MultilineTableCell(Markdown("is"))),
-        Vector(MultilineTableCell(Markdown(" a"))),
-        Vector(MultilineTableCell(Markdown("rectangular"))),
-        Vector(MultilineTableCell(Markdown("table")))))
+        Vector(MultilineTableCell(Vector(Markdown(".It")))),
+        Vector(MultilineTableCell(Vector(Markdown("is")))),
+        Vector(MultilineTableCell(Vector(Markdown(" a")))),
+        Vector(MultilineTableCell(Vector(Markdown("rectangular")))),
+        Vector(MultilineTableCell(Vector(Markdown("table"))))))
   }
 
   it should "parse doesn't cut text that doesn't fit into width separator" in {
@@ -233,11 +233,11 @@ class MultilineTablesRulesSpec extends FlatSpec with Matchers {
       None,
       None,
       Vector(
-        Vector(MultilineTableCell(Markdown(".It is longer"))),
-        Vector(MultilineTableCell(Markdown("than neccesary"))),
-        Vector(MultilineTableCell(Markdown(" and it should"))),
-        Vector(MultilineTableCell(Markdown(" be truncated"))),
-        Vector(MultilineTableCell(Markdown(" :)")))))
+        Vector(MultilineTableCell(Vector(Markdown(".It is longer")))),
+        Vector(MultilineTableCell(Vector(Markdown("than neccesary")))),
+        Vector(MultilineTableCell(Vector(Markdown(" and it should")))),
+        Vector(MultilineTableCell(Vector(Markdown(" be truncated")))),
+        Vector(MultilineTableCell(Vector(Markdown(" :)"))))))
   }
 
   it should "parse table with non equal number of lines in cells" in {
@@ -282,44 +282,44 @@ class MultilineTablesRulesSpec extends FlatSpec with Matchers {
       Vector(25.0f, 75.0f),
       Some(MultilineTableCaption(Vector(Markdown("This is a table caption\\label{table:table_lable_name}")))),
       Some(Vector(
-        MultilineTableCell(Markdown("This header is longer than sep")),
-        MultilineTableCell(Markdown("And this header is also longer than this separator")))),
+        MultilineTableCell(Vector(Markdown("This header is longer than sep"))),
+        MultilineTableCell(Vector(Markdown("And this header is also longer than this separator"))))),
       Vector(
         Vector(
-          MultilineTableCell(Markdown("**Why do we use it?**")),
-          MultilineTableCell(Markdown("""There-are
-                                        |""".stripMargin)),
-          MultilineTableCell(Markdown("**Where can I get some?**")),
-          MultilineTableCell(Markdown("""dummy
-                                        |""".stripMargin)),
-          MultilineTableCell(Markdown("text")),
-          MultilineTableCell(Markdown("printing")),
-          MultilineTableCell(Markdown("**Where does it come from?**")),
-          MultilineTableCell(Markdown("""leap-into
-                                        |""".stripMargin)),
-          MultilineTableCell(Markdown("""variations-join
-                                        |
-                                        |""".stripMargin)),
-          MultilineTableCell(Markdown("**What is Lorem Ipsum?**")),
-          MultilineTableCell(Markdown("""Lorem
-                                        |""".stripMargin)),
-          MultilineTableCell(Markdown("""anything
+          MultilineTableCell(Vector(Markdown("**Why do we use it?**"))),
+          MultilineTableCell(Vector(Markdown("""There-are
                                         |""".stripMargin))),
+          MultilineTableCell(Vector(Markdown("**Where can I get some?**"))),
+          MultilineTableCell(Vector(Markdown("""dummy
+                                        |""".stripMargin))),
+          MultilineTableCell(Vector(Markdown("text"))),
+          MultilineTableCell(Vector(Markdown("printing"))),
+          MultilineTableCell(Vector(Markdown("**Where does it come from?**"))),
+          MultilineTableCell(Vector(Markdown("""leap-into
+                                        |""".stripMargin))),
+          MultilineTableCell(Vector(Markdown("""variations-join
+                                        |
+                                        |""".stripMargin))),
+          MultilineTableCell(Vector(Markdown("**What is Lorem Ipsum?**"))),
+          MultilineTableCell(Vector(Markdown("""Lorem
+                                        |""".stripMargin))),
+          MultilineTableCell(Vector(Markdown("""anything
+                                        |""".stripMargin)))),
         Vector(
-          MultilineTableCell(Markdown("""It is a long established fact that a reader will be
-                                        |distracted by the readable content of a page when looking at""".stripMargin)),
-          MultilineTableCell(Markdown("""It uses a dictionary of over
-                                        |Lorem Ipsum which looks reasonable""".stripMargin)),
-          MultilineTableCell(Markdown("The generated Lorem Ipsum is")),
-          MultilineTableCell(Markdown("or non-characteristic words etc")),
-          MultilineTableCell(Markdown("""It uses a dictionary of over 200
-                                        |you need to be sure there""".stripMargin)),
-          MultilineTableCell(Markdown("""anything embarrassing hidden
+          MultilineTableCell(Vector(Markdown("""It is a long established fact that a reader will be
+                                        |distracted by the readable content of a page when looking at""".stripMargin))),
+          MultilineTableCell(Vector(Markdown("""It uses a dictionary of over
+                                        |Lorem Ipsum which looks reasonable""".stripMargin))),
+          MultilineTableCell(Vector(Markdown("The generated Lorem Ipsum is"))),
+          MultilineTableCell(Vector(Markdown("or non-characteristic words etc"))),
+          MultilineTableCell(Vector(Markdown("""It uses a dictionary of over 200
+                                        |you need to be sure there""".stripMargin))),
+          MultilineTableCell(Vector(Markdown("""anything embarrassing hidden
                                         |you need to be sure there isn't
-                                        |within this period""".stripMargin)),
-          MultilineTableCell(Markdown(""""There are many variations of passages.
-                                        |*randomised words which : 1597 z*""".stripMargin)),
-          MultilineTableCell(Markdown("""but the majority have suffered alteration.
-                                        |*to use a passage: "" (empty string)*""".stripMargin)))))
+                                        |within this period""".stripMargin))),
+          MultilineTableCell(Vector(Markdown(""""There are many variations of passages.
+                                        |*randomised words which : 1597 z*""".stripMargin))),
+          MultilineTableCell(Vector(Markdown("""but the majority have suffered alteration.
+                                        |*to use a passage: "" (empty string)*""".stripMargin))))))
   }
 }

--- a/src/test/scala/MultilineTablesRulesSpec.scala
+++ b/src/test/scala/MultilineTablesRulesSpec.scala
@@ -17,7 +17,7 @@ class MultilineTablesRulesSpec extends FlatSpec with Matchers {
                       |Description cont""".stripMargin))))),
                 widths: Vector[Float] = Vector(25.0f, 75.0f)) = MultilineTableBlock(
     widths,
-    Some(MultilineTableCaption(Vector(Markdown("This is a table caption\\label{table:table_lable_name}")))),
+    Some(MultilineTableCaption(Vector(Markdown("This is a table caption")), Some("table:table_lable_name"))),
     head,
     bodyColumns
   )
@@ -205,7 +205,7 @@ class MultilineTablesRulesSpec extends FlatSpec with Matchers {
     val parser = new MultilineTablesRulesTestSpec(term)
     parser.multiTable.run().get shouldEqual MultilineTableBlock(
       Vector(20.0f, 20.0f, 20.0f, 20.0f, 20.0f),
-      Some(MultilineTableCaption(Vector(Markdown("This is a table caption\\label{table:table_lable_name}")))),
+      Some(MultilineTableCaption(Vector(Markdown("This is a table caption")), Some("table:table_lable_name"))),
       Some(
         Vector(
           MultilineTableCell(Vector(Markdown("Term  1"))),
@@ -280,7 +280,7 @@ class MultilineTablesRulesSpec extends FlatSpec with Matchers {
     val parser = new MultilineTablesRulesTestSpec(term)
     parser.multiTable.run().get shouldEqual MultilineTableBlock(
       Vector(25.0f, 75.0f),
-      Some(MultilineTableCaption(Vector(Markdown("This is a table caption\\label{table:table_lable_name}")))),
+      Some(MultilineTableCaption(Vector(Markdown("This is a table caption")), Some("table:table_lable_name"))),
       Some(Vector(
         MultilineTableCell(Vector(Markdown("This header is longer than sep"))),
         MultilineTableCell(Vector(Markdown("And this header is also longer than this separator"))))),

--- a/src/test/scala/MultilineTablesRulesSpec.scala
+++ b/src/test/scala/MultilineTablesRulesSpec.scala
@@ -17,7 +17,7 @@ class MultilineTablesRulesSpec extends FlatSpec with Matchers {
                       |Description cont""".stripMargin)))),
                 widths: Vector[Float] = Vector(25.0f, 75.0f)) = MultilineTableBlock(
     widths,
-    Some(MultilineTableCaption(Markdown("This is a table caption\\label{table:table_lable_name}"))),
+    Some(MultilineTableCaption(Vector(Markdown("This is a table caption\\label{table:table_lable_name}")))),
     head,
     bodyColumns
   )
@@ -205,7 +205,7 @@ class MultilineTablesRulesSpec extends FlatSpec with Matchers {
     val parser = new MultilineTablesRulesTestSpec(term)
     parser.multiTable.run().get shouldEqual MultilineTableBlock(
       Vector(20.0f, 20.0f, 20.0f, 20.0f, 20.0f),
-      Some(MultilineTableCaption(Markdown("This is a table caption\\label{table:table_lable_name}"))),
+      Some(MultilineTableCaption(Vector(Markdown("This is a table caption\\label{table:table_lable_name}")))),
       Some(
         Vector(
           MultilineTableCell(Markdown("Term  1")),
@@ -280,7 +280,7 @@ class MultilineTablesRulesSpec extends FlatSpec with Matchers {
     val parser = new MultilineTablesRulesTestSpec(term)
     parser.multiTable.run().get shouldEqual MultilineTableBlock(
       Vector(25.0f, 75.0f),
-      Some(MultilineTableCaption(Markdown("This is a table caption\\label{table:table_lable_name}"))),
+      Some(MultilineTableCaption(Vector(Markdown("This is a table caption\\label{table:table_lable_name}")))),
       Some(Vector(
         MultilineTableCell(Markdown("This header is longer than sep")),
         MultilineTableCell(Markdown("And this header is also longer than this separator")))),


### PR DESCRIPTION
## Summary of the changes

- Altered Multiline Table's definition and definitions of some of the nested elements (#26)
- Implemented function that transforms so-called raw AST (one that may contain not parsed chunks of `Markdown` in self-titled block type) into a complete tree (#27)
- Designed a set of tests for #27 

## Further work 
- Design test cases for parse failures
- Gather links and attach them to target blocks