### PR TITLE
#31 multiline table rule bug

### DIFF
--- a/src/main/scala/com/mdpeg/MultilineTablesRules.scala
+++ b/src/main/scala/com/mdpeg/MultilineTablesRules.scala
@@ -1,10 +1,10 @@
 package com.mdpeg
+
 import org.parboiled2._
 
 import scala.collection.immutable.::
 import scala.compat.Platform.EOL
 import scala.util.Success
-import scala.util.matching.Regex
 
 trait MultilineTablesRules {
   this: Parser with PrimitiveRules =>
@@ -14,37 +14,50 @@ trait MultilineTablesRules {
 
   def multiTable: Rule1[MultilineTableBlock] = {
     /*_*/
-    rule(
-      tableHeadRaw.? ~ tableBody ~ tableBorder ~ tableCaption.? ~ capture(nl.* | blankLine.*) ~>
-        ((head: Option[Vector[String]], body: (Vector[List[String]], String), caption: Option[String], _: String) => constructTable(head, body, caption))
-    )
+    rule(tableHeadRaw.? ~ tableBody ~ tableBorder ~ tableCaption.? ~ capture(nl.* | blankLine.*) ~>
+      ((head:Option[Vector[String]], body: (Vector[List[String]], String), caption: Option[String], _: String) =>
+        constructTable(head, body, caption)))
     /*_*/
   }
+
   def tableHeadRaw: Rule1[Vector[String]] = {
     def headContentLine = rule(capture(atomic(!tableHeadWidthSeparator ~ anyLineTable | blankLine)))
+
     def contents: Rule1[Seq[String]] = rule(headContentLine.+)
-    rule(tableBorder ~ capture(contents) ~ &(tableHeadWidthSeparator) ~> ((headContent: Seq[String], _: Any) => headContent.toVector))
+
+    rule(tableBorder ~ capture(contents) ~ &(tableHeadWidthSeparator) ~> ((headContent: Seq[String], _: Any) =>
+      headContent.toVector))
   }
+
   def tableBody: Rule1[(RawBody, WidthSeparator)] = {
     def bodyContentLine = rule(capture(atomic(!tableBorder ~ anyLineTable | blankLine)))
+
     def contents = rule(bodyContentLine.+)
-    rule(capture(tableHeadWidthSeparator) ~ capture(contents) ~>
-      ((sep: String, contents: Seq[String], _: Any) => parseBodyContent(sep, contents)))
+
+    rule(capture(tableHeadWidthSeparator) ~ capture(contents) ~> ((sep: String, contents: Seq[String], _: Any) =>
+      parseBodyContent(sep, contents)))
   }
+
   def tableCaption: Rule1[String] = {
-    rule(atomic("Table: " ~ capture(anyCharTable.+) ~ nl.?))
+    rule(atomic("Table:" ~ sps ~ capture(anyCharTable.+) ~ nl.?))
   }
+
   def tableHeadWidthSeparator: Rule0 = {
     // ToDO in case of 1 column it can't be distinguished from tableBorder rule, so no !tableBorder applied here yet
-    rule(atomic(!horizontalRule ~ (dashes ~ sp.*).+ ~ nl.?))
+    rule(atomic(!horizontalRule ~ (dashes ~ sps).+ ~ nl.?))
   }
+
   def tableBorder: Rule0 = rule(atomic(!horizontalRule ~ dashes ~ nl))
+
   def dashes: Rule0 = rule((3 to 150).times("-"))
-  private def anyLineTable: Rule0 = rule(!nl ~ !EOI ~ anyCharTable.* ~ (nl | ""))
-  private def anyCharTable: Rule0 = rule(anyChar | backTick)
+
+  private def anyLineTable: Rule0 = rule(anyCharTable.+ ~ (nl | ""))
+
+  private def anyCharTable: Rule0 = rule(!nl ~ !EOI ~ ANY)
 
   //aux functions
-  private def constructTable(head: Option[Vector[String]], bodyWithWidth: (RawBody, WidthSeparator), caption: Option[String]): MultilineTableBlock = {
+  private def constructTable(head: Option[Vector[String]], bodyWithWidth: (RawBody, WidthSeparator), caption:
+  Option[String]): MultilineTableBlock = {
     def calculateRelativeWidths(width: String): Vector[Float] = {
       // todo improve calculation precision, use Largest Remainder Method and improve upon relative error
       val columnWidths = width.split(' ').filter(_ != "").map(_.length)
@@ -54,22 +67,30 @@ trait MultilineTablesRules {
 
     val (body, width: String) = bodyWithWidth
     val parsedHead = head.map(parseHeadContent(width, _))
-
     val relativeWidths = calculateRelativeWidths(width)
-    val tableCaption: Option[MultilineTableCaption] = caption.map{inline =>
-      val labelPattern = """\\label\{(.*)\}""".r
-      val maybeLabel = (for (ex <- labelPattern.findAllMatchIn(inline)) yield (ex.group(0), ex.group(1))).toVector.headOption
-      val maybeWholeMatch = maybeLabel.map(_._1).getOrElse("")
-      MultilineTableCaption(Vector(Markdown(inline.replace(maybeWholeMatch, ""))), maybeLabel.map(_._2))
+
+    val tableCaption: Option[MultilineTableCaption] = caption.
+      map { inline =>
+        val labelPattern = """\\label\{(.*)\}""".r
+        val maybeLabel = (for (ex <- labelPattern.findAllMatchIn(inline)) yield (ex.group(0), ex.group(1))).toVector
+          .headOption
+        val maybeWholeMatch = maybeLabel.map(_._1).getOrElse("")
+          MultilineTableCaption(Vector(Markdown(inline.replace(maybeWholeMatch, ""))), maybeLabel.map(_._2))
     }
-    val headRow: Option[MultilineTableRow] = parsedHead.map(_.map(inline => MultilineTableCell(Vector(Markdown(inline)))).toVector)
-    val bodyColumns: Vector[MultilineTableColumn] = body.map(_.map(inline => MultilineTableCell(Vector(Markdown(inline)))).toVector)
+
+    val headRow: Option[MultilineTableRow] = parsedHead.
+      map(_.map(inline => MultilineTableCell(Vector(Markdown(inline)))).toVector)
+
+    val bodyColumns: Vector[MultilineTableColumn] = body.
+      map(_.map(inline => MultilineTableCell(Vector(Markdown(inline)))).toVector)
+
     MultilineTableBlock(relativeWidths, tableCaption, headRow, bodyColumns)
   }
 
   /**
     * Splits header content into cells using 'width separator'
-    * @param sep width separator string, '-- --- --'
+    *
+    * @param sep      width separator string, '-- --- --'
     * @param contents raw contents of the table head to be split into cells; blank lines removed, that is,
     *                 there's no support for multi-row headers
     * @return vector of cells in a header row
@@ -85,17 +106,19 @@ trait MultilineTablesRules {
     val widths = sep.replaceAll("\r", "").replace("\n", "")
     val rows = contents.filter(!isEmptyString(_)).toList
     val indexes = " -".r.findAllMatchIn(widths).map(_.start + 1).toList
-    val cells =
-      transposeAnyShape(rows.map(s => listSplit(indexes, s))).
-      map(_.reduce((s1,s2) => trimEndWithEnding(s1) + EOL + s2)).
-      map(s => trimEndWithEnding(s))
+
+    val cells = rows.map(s => listSplit(indexes, s)) |>
+      transposeAnyShape |> {x =>
+        x.map(_.reduce(trimEndWithEnding(_) + EOL + _)).map(trimEndWithEnding)
+      }
 
     cells
   }
 
   /**
     * Splits body content into cells using 'width separator'
-    * @param sep width separator string, '-- --- --'
+    *
+    * @param sep      width separator string, '-- --- --'
     * @param contents raw contents of the table body to be split into cells; blank lines are split points
     * @return vector of columns containing cells.
     */
@@ -111,32 +134,30 @@ trait MultilineTablesRules {
     val widths = sep.replaceAll("\r", "").replace("\n", "")
 
     //split into rows by blank lines
-    val rows: List[List[String]] = contents.
-      foldLeft(List.empty[List[String]]) {
-        case (acc, currentLine) =>
-          val isEmptyLine = isEmptyString(currentLine)
-          val cl = currentLine.replaceAll("\r", "").replace("\n", "")
-          acc match {
-            case x :: _ if isEmptyLine && x.isEmpty => acc
-            case _ :: _ if isEmptyLine => List.empty[String] :: acc
-            case x :: xs => (x :+ cl) :: xs
-            case Nil => List(cl) :: Nil
-          }
-      }.
-      reverse.
-      filter(_.nonEmpty)
+    val rows: List[List[String]] = contents.foldLeft(List.empty[List[String]]) { case (acc, currentLine) =>
+      val isEmptyLine = isEmptyString(currentLine)
+      val cl = currentLine.replaceAll("\r", "").replace("\n", "")
+      acc match {
+        case x :: _ if isEmptyLine && x.isEmpty => acc
+        case _ :: _ if isEmptyLine => List.empty[String] :: acc
+        case x :: xs => (x :+ cl) :: xs
+        case Nil => List(cl) :: Nil
+      }
+    }.reverse.filter(_.nonEmpty)
 
     //split by every change from spaces to dashes in width separator
     val indexes = " -".r.findAllMatchIn(widths).map(_.start + 1).toList
-    val cells: Vector[List[String]] =
-      transposeAnyShape(rows.
-          map(_.map(s => listSplit(indexes, s))).
-          map(_ |> transposeAnyShape |> (_.map(strings => trimEnd(strings.reduce((s1, s2) => trimEnd(s1) + EOL + s2)))))
-      ).toVector
+    val cells: Vector[List[String]] = rows.
+      map(_.map(s => listSplit(indexes, s))).
+      map(_ |> transposeAnyShape |> (_.map(_.reduce(trimEnd(_) + EOL + _) |> trimEnd))) |>
+      transposeAnyShape |>
+      (_.toVector)
+
     (cells, widths)
   }
 
   // ToDo investigate hot to re-use parser on different inputs in order to avoid creation of a new parser on every line
   // needed to facilitate some internal processing
   private class PrimitvePaserHelper(val input: ParserInput) extends Parser with PrimitiveRules
+
 }

--- a/src/test/scala/BlockParserSpec.scala
+++ b/src/test/scala/BlockParserSpec.scala
@@ -224,4 +224,23 @@ class BlockParserSpec extends FlatSpec with Matchers {
           Markdown("sub 2"))
         ))
   }
+
+  it should "parse a table without caption followed by a text" in {
+    val term =
+      """--------------------------------------------------------------------------------
+        |Term                  Description
+        |----------------      ------------------------------------------------
+        |cell 1                cell 2
+        |--------------------------------------------------------------------------------
+        |
+        |kio""".stripMargin
+    val parser = new BlockParser(term)
+    Vector(MultilineTableBlock(Vector(25.0f, 75.0f),
+      None,
+      Some(Vector(MultilineTableCell(Vector(Markdown("Term"))), MultilineTableCell(Vector(Markdown("Description"))))),
+      Vector(Vector(MultilineTableCell(Vector(Markdown("cell 1")))),
+        Vector(MultilineTableCell(Vector(Markdown("cell 2")))))),
+      Plain(Vector(Text("kio"))))
+
+  }
 }

--- a/src/test/scala/MultilineTablesRulesSpec.scala
+++ b/src/test/scala/MultilineTablesRulesSpec.scala
@@ -1,6 +1,9 @@
+import com.mdpeg.Parser.{fileText, parser}
 import com.mdpeg._
-import org.parboiled2.{ParseError, Parser, ParserInput}
+import org.parboiled2.{ErrorFormatter, ParseError, Parser, ParserInput}
 import org.scalatest.{FlatSpec, Matchers}
+
+import scala.util.{Failure, Success}
 
 class MultilineTablesRulesSpec extends FlatSpec with Matchers {
 
@@ -23,22 +26,40 @@ class MultilineTablesRulesSpec extends FlatSpec with Matchers {
   )
 
   it should "parse table border" in {
-    val term ="""-------------------------------------------------------------------------------
-      |""".stripMargin
+    val term =
+      """-------------------------------------------------------------------------------
+        |""".stripMargin
     val parsed = new MultilineTablesRulesTestSpec(term).tableBorder.run()
-    noException should be thrownBy { parsed.get }
+    noException should be thrownBy {
+      parsed.get
+    }
   }
 
   it should "parse table caption" in {
-    val term = """Table: This is a table caption\\label{table:table_lable_name}"""
+    val term =
+      """-------------------------------------------------------------
+        |Table: This is a table caption\\label{table:table_lable_name}
+        |
+        |
+        |""".stripMargin
     val parsed = new MultilineTablesRulesTestSpec(term).tableCaption.run()
-    noException should be thrownBy { parsed.get }
+    parsed.get shouldEqual Some("""This is a table caption\\label{table:table_lable_name}""")
+  }
+
+  it should "parse table empty caption" in {
+    val term =
+      """-------------------------------------------------------------
+        |
+        |
+        |""".stripMargin
+    val parsed = new MultilineTablesRulesTestSpec(term).tableCaption.run()
+    parsed.get shouldEqual None
   }
 
   it should "parse table's width separator" in {
     val term =
-        """-----------                       ---------------------------------
-          |""".stripMargin
+      """-----------                       ---------------------------------
+        |""".stripMargin
     val term2 =
       """-----------  ---  --- --- --- --- ---   -------  ------ ---------------------------------
         |""".stripMargin
@@ -48,9 +69,15 @@ class MultilineTablesRulesSpec extends FlatSpec with Matchers {
     val parsed = new MultilineTablesRulesTestSpec(term).tableHeadWidthSeparator.run()
     val parsed2 = new MultilineTablesRulesTestSpec(term2).tableHeadWidthSeparator.run()
     val parsed3 = new MultilineTablesRulesTestSpec(term3).tableHeadWidthSeparator.run()
-    noException should be thrownBy { parsed.get }
-    noException should be thrownBy { parsed2.get }
-    noException should be thrownBy { parsed3.get }
+    noException should be thrownBy {
+      parsed.get
+    }
+    noException should be thrownBy {
+      parsed2.get
+    }
+    noException should be thrownBy {
+      parsed3.get
+    }
   }
 
   it should "parse table a one-line tall heading" in {
@@ -60,7 +87,9 @@ class MultilineTablesRulesSpec extends FlatSpec with Matchers {
         |----------------      ------------------------------------------------
         |""".stripMargin
     val parsed = new MultilineTablesRulesTestSpec(term).tableHeadRaw.run()
-    noException should be thrownBy { parsed.get }
+    noException should be thrownBy {
+      parsed.get
+    }
   }
 
   it should "parse table a multi-line tall heading with blank lines" in {
@@ -75,7 +104,9 @@ class MultilineTablesRulesSpec extends FlatSpec with Matchers {
         |----------------      ------------------------------------------------
         |""".stripMargin
     val parsed = new MultilineTablesRulesTestSpec(term).tableHeadRaw.run()
-    noException should be thrownBy { parsed.get }
+    noException should be thrownBy {
+      parsed.get
+    }
   }
 
   it should "fail parsing table with no content lines" in {
@@ -84,7 +115,9 @@ class MultilineTablesRulesSpec extends FlatSpec with Matchers {
         |----------------      ------------------------------------------------
         |""".stripMargin
     val parsed = new MultilineTablesRulesTestSpec(term).tableHeadRaw.run()
-    a [ParseError] should be thrownBy { parsed.get }
+    a[ParseError] should be thrownBy {
+      parsed.get
+    }
   }
 
   it should "parse table content for table without head" in {
@@ -100,7 +133,9 @@ class MultilineTablesRulesSpec extends FlatSpec with Matchers {
         |
         |Many                  desktop publishing packages and""".stripMargin
     val parsed = new MultilineTablesRulesTestSpec(term).tableBody.run()
-    noException should be thrownBy { parsed.get }
+    noException should be thrownBy {
+      parsed.get
+    }
   }
 
   it should "parse table with header and caption" in {
@@ -127,7 +162,7 @@ class MultilineTablesRulesSpec extends FlatSpec with Matchers {
         MultilineTableCell(Vector(Markdown("is a long established fact that"))),
         MultilineTableCell(Vector(Markdown("The point of using Lorem Ipsum is"))),
         MultilineTableCell(Vector(Markdown("desktop publishing packages and")))))
-      )
+    )
   }
 
   it should "separate table rows by blank line" in {
@@ -147,12 +182,14 @@ class MultilineTablesRulesSpec extends FlatSpec with Matchers {
     parser.multiTable.run().get shouldEqual tableMock(Vector(
       Vector(
         MultilineTableCell(Vector(Markdown(".It"))),
-        MultilineTableCell(Vector(Markdown("""CAPSED WORD
+        MultilineTableCell(Vector(Markdown(
+          """CAPSED WORD
             |Many""".stripMargin)))),
       Vector(
         MultilineTableCell(Vector(Markdown("is a long established fact that"))),
-        MultilineTableCell(Vector(Markdown("""The point of using Lorem Ipsum is
-                                      |desktop publishing packages and""".stripMargin))))))
+        MultilineTableCell(Vector(Markdown(
+          """The point of using Lorem Ipsum is
+            |desktop publishing packages and""".stripMargin))))))
   }
 
   it should "eliminate trailing empty line in body row" in {
@@ -172,7 +209,7 @@ class MultilineTablesRulesSpec extends FlatSpec with Matchers {
     parser.multiTable.run().get shouldEqual tableMock(Vector(
       Vector(MultilineTableCell(Vector(Markdown(".It")))),
       Vector(MultilineTableCell(Vector(Markdown("is a long established fact that")))
-    )))
+      )))
   }
 
   it should "parse 1x1 table with header" in {
@@ -189,8 +226,9 @@ class MultilineTablesRulesSpec extends FlatSpec with Matchers {
     val parser = new MultilineTablesRulesTestSpec(term)
     parser.multiTable.run().get shouldEqual tableMock(
       Vector(Vector(MultilineTableCell(Vector(Markdown(".It"))))),
-      Some(Vector(MultilineTableCell(Vector(Markdown("""Term  1
-                                                |Term  cont""".stripMargin))))),
+      Some(Vector(MultilineTableCell(Vector(Markdown(
+        """Term  1
+          |Term  cont""".stripMargin))))),
       Vector(100.0f))
   }
 
@@ -287,43 +325,55 @@ class MultilineTablesRulesSpec extends FlatSpec with Matchers {
       Vector(
         Vector(
           MultilineTableCell(Vector(Markdown("**Why do we use it?**"))),
-          MultilineTableCell(Vector(Markdown("""There-are
-                                        |""".stripMargin))),
+          MultilineTableCell(Vector(Markdown(
+            """There-are
+              |""".stripMargin))),
           MultilineTableCell(Vector(Markdown("**Where can I get some?**"))),
-          MultilineTableCell(Vector(Markdown("""dummy
-                                        |""".stripMargin))),
+          MultilineTableCell(Vector(Markdown(
+            """dummy
+              |""".stripMargin))),
           MultilineTableCell(Vector(Markdown("text"))),
           MultilineTableCell(Vector(Markdown("printing"))),
           MultilineTableCell(Vector(Markdown("**Where does it come from?**"))),
-          MultilineTableCell(Vector(Markdown("""leap-into
-                                        |""".stripMargin))),
-          MultilineTableCell(Vector(Markdown("""variations-join
-                                        |
-                                        |""".stripMargin))),
+          MultilineTableCell(Vector(Markdown(
+            """leap-into
+              |""".stripMargin))),
+          MultilineTableCell(Vector(Markdown(
+            """variations-join
+              |
+              |""".stripMargin))),
           MultilineTableCell(Vector(Markdown("**What is Lorem Ipsum?**"))),
-          MultilineTableCell(Vector(Markdown("""Lorem
-                                        |""".stripMargin))),
-          MultilineTableCell(Vector(Markdown("""anything
-                                        |""".stripMargin)))),
+          MultilineTableCell(Vector(Markdown(
+            """Lorem
+              |""".stripMargin))),
+          MultilineTableCell(Vector(Markdown(
+            """anything
+              |""".stripMargin)))),
         Vector(
           MultilineTableCell(Vector(Markdown(""))),
-          MultilineTableCell(Vector(Markdown("""It is a long established fact that a reader will be
-                                        |distracted by the readable content of a page when looking at""".stripMargin))),
+          MultilineTableCell(Vector(Markdown(
+            """It is a long established fact that a reader will be
+              |distracted by the readable content of a page when looking at""".stripMargin))),
           MultilineTableCell(Vector(Markdown(""))),
-          MultilineTableCell(Vector(Markdown("""It uses a dictionary of over
-                                        |Lorem Ipsum which looks reasonable""".stripMargin))),
+          MultilineTableCell(Vector(Markdown(
+            """It uses a dictionary of over
+              |Lorem Ipsum which looks reasonable""".stripMargin))),
           MultilineTableCell(Vector(Markdown("The generated Lorem Ipsum is"))),
           MultilineTableCell(Vector(Markdown("or non-characteristic words etc"))),
           MultilineTableCell(Vector(Markdown(""))),
-          MultilineTableCell(Vector(Markdown("""It uses a dictionary of over 200
-                                        |you need to be sure there""".stripMargin))),
-          MultilineTableCell(Vector(Markdown("""anything embarrassing hidden
-                                        |you need to be sure there isn't
-                                        |within this period""".stripMargin))),
+          MultilineTableCell(Vector(Markdown(
+            """It uses a dictionary of over 200
+              |you need to be sure there""".stripMargin))),
+          MultilineTableCell(Vector(Markdown(
+            """anything embarrassing hidden
+              |you need to be sure there isn't
+              |within this period""".stripMargin))),
           MultilineTableCell(Vector(Markdown(""))),
-          MultilineTableCell(Vector(Markdown(""""There are many variations of passages.
-                                        |*randomised words which : 1597 z*""".stripMargin))),
-          MultilineTableCell(Vector(Markdown("""but the majority have suffered alteration.
-                                        |*to use a passage: "" (empty string)*""".stripMargin))))))
+          MultilineTableCell(Vector(Markdown(
+            """"There are many variations of passages.
+              |*randomised words which : 1597 z*""".stripMargin))),
+          MultilineTableCell(Vector(Markdown(
+            """but the majority have suffered alteration.
+              |*to use a passage: "" (empty string)*""".stripMargin))))))
   }
 }


### PR DESCRIPTION
Fixed the issue #31.
The gist of the issue was `!horizontalRule` guardian check in the table border rule. 
I made it less restrictive in that aspect by not checking it when there's no table caption.